### PR TITLE
Centralize Redis Client Usage and Add Caching in LeaderboardService

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@nestjs/axios": "^4.0.0",
         "@nestjs/common": "^11.0.12",
-        "@nestjs/config": "^4.0.1",
+        "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.12",
         "@nestjs/event-emitter": "^3.0.1",
         "@nestjs/jwt": "^11.0.0",
@@ -27,6 +27,7 @@
         "class-validator": "^0.14.1",
         "fast-csv": "^5.0.2",
         "google-auth-library": "^9.15.1",
+        "ioredis": "^5.6.1",
         "oauth2client": "^1.0.0",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
@@ -1341,6 +1342,11 @@
         }
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2413,10 +2419,9 @@
       }
     },
     "node_modules/@nestjs/config": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.1.tgz",
-      "integrity": "sha512-0hr6lKS//Wf8A6VcV69ts8uD0fke6jtmmmXSxzvwAzOM/HEXEKYEp21nRU+cpYxlYqm7Khb0oTOoVuDGk+AWUw==",
-      "license": "MIT",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.2.tgz",
+      "integrity": "sha512-McMW6EXtpc8+CwTUwFdg6h7dYcBUpH5iUILCclAsa+MbCEvC9ZKu4dCHRlJqALuhjLw97pbQu62l4+wRwGeZqA==",
       "dependencies": {
         "dotenv": "16.4.7",
         "dotenv-expand": "12.0.1",
@@ -5532,6 +5537,14 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5949,6 +5962,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -8108,6 +8129,29 @@
         "kind-of": "^6.0.2"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.1.tgz",
+      "integrity": "sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -9367,6 +9411,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
@@ -9384,6 +9433,11 @@
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
       "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
@@ -11488,6 +11542,25 @@
         "esprima": "~4.0.0"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -12346,6 +12419,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/starknet": {
       "version": "6.24.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@nestjs/axios": "^4.0.0",
     "@nestjs/common": "^11.0.12",
-    "@nestjs/config": "^4.0.1",
+    "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.12",
     "@nestjs/event-emitter": "^3.0.1",
     "@nestjs/jwt": "^11.0.0",
@@ -39,6 +39,7 @@
     "class-validator": "^0.14.1",
     "fast-csv": "^5.0.2",
     "google-auth-library": "^9.15.1",
+    "ioredis": "^5.6.1",
     "oauth2client": "^1.0.0",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,7 +3,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
-
+import { RedisModule } from './redis/redis.module';
 import { AuthModule } from './auth/auth.module';
 import appConfig from './config/app.config';
 import databaseConfig from './config/database.config';
@@ -50,13 +50,14 @@ import { AchievementModule } from './achievement/achievement.module';
     UsersModule,
     LeaderboardModule,
     CommonModule,
+    RedisModule,
     BlockchainModule,
     BadgeModule,
     TimeFilterModule,
     IQAssessmentModule,
     PuzzleModule,
     GamificationModule,
-    AchievementModule
+    AchievementModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/redis/redis.constants.ts
+++ b/src/redis/redis.constants.ts
@@ -1,0 +1,2 @@
+/* eslint-disable prettier/prettier */
+export const REDIS_CLIENT = 'REDIS_CLIENT';

--- a/src/redis/redis.module.ts
+++ b/src/redis/redis.module.ts
@@ -1,0 +1,23 @@
+/* eslint-disable prettier/prettier */
+import { Global, Module, OnModuleDestroy, Inject } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { redisProvider } from './redis.provider';
+import { REDIS_CLIENT } from './redis.constants';
+import Redis from 'ioredis';
+
+@Global()
+@Module({
+  imports: [ConfigModule],
+  providers: [redisProvider],
+  exports: [redisProvider],
+})
+export class RedisModule implements OnModuleDestroy {
+  constructor(@Inject(REDIS_CLIENT) private readonly redis: Redis) {}
+
+  async onModuleDestroy() {
+    if (this.redis) {
+      await this.redis.quit();
+      console.log('🧹 Redis disconnected gracefully');
+    }
+  }
+}

--- a/src/redis/redis.provider.ts
+++ b/src/redis/redis.provider.ts
@@ -1,0 +1,23 @@
+/* eslint-disable prettier/prettier */
+import { Provider } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+import { REDIS_CLIENT } from './redis.constants';
+
+export const redisProvider: Provider = {
+  provide: REDIS_CLIENT,
+  useFactory: (configService: ConfigService) => {
+    const redisUrl = configService.get<string>('REDIS_URL');
+    if (!redisUrl) {
+      throw new Error('REDIS_URL not defined in environment variables');
+    }
+
+    const client = new Redis(redisUrl);
+
+    client.on('connect', () => console.log('Redis connected'));
+    client.on('error', (err) => console.error('Redis error:', err));
+
+    return client;
+  },
+  inject: [ConfigService],
+};


### PR DESCRIPTION
## Description

This PR introduces a **singleton Redis client** via a global `RedisModule` and integrates it into the existing `LeaderboardService` to enable caching of leaderboard queries. This improves performance by reducing redundant database queries and ensures consistent Redis usage across the application.

- Redis client is injected via the custom `REDIS_CLIENT` token.
- Caching is applied in `getLeaderboard()` with a 60-second expiration.
- Redis read/write errors are gracefully handled with logs.
- No new DTOs were added; cached data is typed as `any[]` to avoid unsafe `any` warnings.
- Existing functionality of `LeaderboardService` is preserved without modifications to other providers.

## Changes

- Inject `Redis` client into `LeaderboardService` constructor.
- Modify `getLeaderboard()` to:
  - Check Redis cache first using a composed cache key.
  - Parse and return cached data if available.
  - Query the leaderboard service on cache miss.
  - Cache fresh results with expiration.
- Add try/catch blocks around Redis operations to handle connection or runtime errors.
- Update imports to include `Redis` and `REDIS_CLIENT`.

## How to Test

1. Ensure Redis is running locally or configured via `.env` with `REDIS_URL`.
2. Start the NestJS app.
3. Call leaderboard endpoints or methods to trigger caching.
4. Observe Redis cache hits by inspecting logs or directly querying Redis.
5. Confirm leaderboard data is returned correctly with or without cache.
6. Shut down app gracefully to verify Redis disconnect (if implemented).

## Notes

- This PR focuses solely on caching inside `LeaderboardService`; other services remain unaffected.
- The Redis client lifecycle is managed globally in the `RedisModule`.
- For type safety, cached data is returned as `any[]` due to lack of a dedicated DTO.
- Future improvements could include cache invalidation on leaderboard updates.
