### PR TITLE
feat(puzzles): implemente POST API puzzles endpoint with category validation,  fixes #165

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,3 +10,4 @@ DATABASE_LOAD= true
 GOOGLE_CLIENT_ID= yourGoogleOauthClientId
 GOOGLE_CLIENT_SECRET= yourGoogleOauthClientSecrete
 GOOGLE_CALLBACK_URL= yourGoogleOauthcallbackUrl
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,6 +46,7 @@
     "passport-google-oauth20": "^2.0.0",
     "pdfkit": "^0.17.1",
     "pg": "^8.14.1",
+    "redis": "^5.10.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "sqlite3": "^5.1.7",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,8 @@ import databaseConfig from './config/database.config';
 import { UsersModule } from './users/users.module';
 import { CommonModule } from './common/common.module';
 import { BlockchainModule } from './blockchain/blockchain.module';
+import { CategoriesModule } from './categories/categories.module';
+import { PuzzlesModule } from './puzzles/puzzles.module';
 import { AppService } from './app.service';
 import { AppController } from './app.controller';
 
@@ -59,6 +61,8 @@ import { AppController } from './app.controller';
     CommonModule,
     RedisModule,
     BlockchainModule,
+    CategoriesModule,
+    PuzzlesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/categories/categories.module.ts
+++ b/backend/src/categories/categories.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Category } from './entities/category.entity';
+import { CategoriesService } from './providers/categories.service';
+import { FindCategoryByIdService } from './providers/find-category-by-id.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Category])],
+  providers: [CategoriesService, FindCategoryByIdService],
+  exports: [CategoriesService],
+})
+export class CategoriesModule {}

--- a/backend/src/categories/entities/category.entity.ts
+++ b/backend/src/categories/entities/category.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  OneToMany,
+} from 'typeorm';
+import { Puzzle } from '../../puzzles/entities/puzzle.entity';
+
+@Entity('categories')
+export class Category {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: false, unique: true })
+  @Index()
+  name: string;
+
+  @Column({ name: 'is_active', type: 'boolean', default: true })
+  isActive: boolean;
+
+  @OneToMany(() => Puzzle, (puzzle) => puzzle.category)
+  puzzles: Puzzle[];
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/categories/providers/categories.service.ts
+++ b/backend/src/categories/providers/categories.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { FindCategoryByIdService } from './find-category-by-id.service';
+import { Category } from '../entities/category.entity';
+
+@Injectable()
+export class CategoriesService {
+  constructor(
+    private readonly findCategoryByIdService: FindCategoryByIdService,
+  ) {}
+
+  /**
+   * Find a category by ID (validates existence and active status)
+   * @param id - Category UUID
+   * @returns Category if valid
+   * @throws NotFoundException if not found or inactive
+   */
+  public async findById(id: string): Promise<Category> {
+    return this.findCategoryByIdService.execute(id);
+  }
+}

--- a/backend/src/categories/providers/find-category-by-id.service.ts
+++ b/backend/src/categories/providers/find-category-by-id.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Category } from '../entities/category.entity';
+
+@Injectable()
+export class FindCategoryByIdService {
+  constructor(
+    @InjectRepository(Category)
+    private readonly categoryRepository: Repository<Category>,
+  ) {}
+
+  /**
+   * Finds a category by ID and validates it exists and is active
+   * @param id - Category UUID
+   * @returns Category if found and active
+   * @throws NotFoundException if category not found or inactive
+   */
+  async execute(id: string): Promise<Category> {
+    const category = await this.categoryRepository.findOne({ where: { id } });
+
+    if (!category) {
+      throw new NotFoundException(`Category with ID ${id} not found`);
+    }
+
+    if (!category.isActive) {
+      throw new NotFoundException(`Category with ID ${id} is not active`);
+    }
+
+    return category;
+  }
+}

--- a/backend/src/puzzles/controllers/puzzles.controller.ts
+++ b/backend/src/puzzles/controllers/puzzles.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { PuzzlesService } from '../providers/puzzles.service';
+import { CreatePuzzleDto } from '../dtos/create-puzzle.dto';
+import { Puzzle } from '../entities/puzzle.entity';
+
+@Controller('puzzles')
+@ApiTags('puzzles')
+export class PuzzlesController {
+  constructor(private readonly puzzlesService: PuzzlesService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new puzzle' })
+  @ApiResponse({
+    status: 201,
+    description: 'Puzzle created successfully',
+    type: Puzzle,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input' })
+  @ApiResponse({ status: 404, description: 'Category not found or inactive' })
+  async create(@Body() createPuzzleDto: CreatePuzzleDto): Promise<Puzzle> {
+    return this.puzzlesService.create(createPuzzleDto);
+  }
+}

--- a/backend/src/puzzles/entities/puzzle.entity.ts
+++ b/backend/src/puzzles/entities/puzzle.entity.ts
@@ -5,8 +5,11 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   Index,
+  ManyToOne,
+  JoinColumn,
 } from 'typeorm';
 import { PuzzleDifficulty } from '../enums/puzzle-difficulty.enum';
+import { Category } from '../../categories/entities/category.entity';
 
 @Entity('puzzles')
 export class Puzzle {
@@ -33,6 +36,10 @@ export class Puzzle {
   @Column({ type: 'uuid', nullable: false })
   @Index()
   categoryId: string;
+
+  @ManyToOne(() => Category, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'categoryId' })
+  category: Category;
 
   @Column({ type: 'integer', nullable: false })
   points: number;

--- a/backend/src/puzzles/providers/create-puzzle.service.ts
+++ b/backend/src/puzzles/providers/create-puzzle.service.ts
@@ -1,0 +1,54 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Puzzle } from '../entities/puzzle.entity';
+import { CreatePuzzleDto } from '../dtos/create-puzzle.dto';
+import { CategoriesService } from '../../categories/providers/categories.service';
+
+@Injectable()
+export class CreatePuzzleService {
+  constructor(
+    @InjectRepository(Puzzle)
+    private readonly puzzleRepository: Repository<Puzzle>,
+    private readonly categoriesService: CategoriesService,
+  ) {}
+
+  /**
+   * Creates a new puzzle after validating category and setting defaults
+   * @param createPuzzleDto - Validated puzzle data from controller
+   * @returns Created puzzle entity
+   * @throws NotFoundException if category doesn't exist or is inactive (from CategoriesService)
+   * @throws InternalServerErrorException if database operation fails
+   */
+  async execute(createPuzzleDto: CreatePuzzleDto): Promise<Puzzle> {
+    // Step 1: Validate category exists and is active
+    // This throws NotFoundException (404) if category is invalid
+    await this.categoriesService.findById(createPuzzleDto.categoryId);
+
+    // Step 2: Set default points based on difficulty if not provided
+    // Uses the existing method in CreatePuzzleDto that calls getPointsByDifficulty()
+    createPuzzleDto.setDefaultPointsIfNeeded();
+
+    // Step 3: Create and persist puzzle
+    try {
+      const puzzle = this.puzzleRepository.create({
+        question: createPuzzleDto.question,
+        options: createPuzzleDto.options,
+        correctAnswer: createPuzzleDto.correctAnswer,
+        difficulty: createPuzzleDto.difficulty,
+        categoryId: createPuzzleDto.categoryId,
+        points: createPuzzleDto.points,
+        timeLimit: createPuzzleDto.timeLimit,
+        explanation: createPuzzleDto.explanation,
+      });
+
+      // Step 4: Save to database and return
+      return await this.puzzleRepository.save(puzzle);
+    } catch (error) {
+      throw new InternalServerErrorException('Failed to create puzzle');
+    }
+  }
+}

--- a/backend/src/puzzles/providers/puzzles.service.ts
+++ b/backend/src/puzzles/providers/puzzles.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { CreatePuzzleService } from './create-puzzle.service';
+import { CreatePuzzleDto } from '../dtos/create-puzzle.dto';
+import { Puzzle } from '../entities/puzzle.entity';
+
+@Injectable()
+export class PuzzlesService {
+  constructor(
+    private readonly createPuzzleService: CreatePuzzleService,
+  ) {}
+
+  /**
+   * Create a new puzzle
+   * @param createPuzzleDto - Validated puzzle data
+   * @returns Created puzzle entity
+   */
+  public async create(createPuzzleDto: CreatePuzzleDto): Promise<Puzzle> {
+    return this.createPuzzleService.execute(createPuzzleDto);
+  }
+}

--- a/backend/src/puzzles/puzzles.module.ts
+++ b/backend/src/puzzles/puzzles.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Puzzle } from './entities/puzzle.entity';
+import { PuzzlesController } from './controllers/puzzles.controller';
+import { PuzzlesService } from './providers/puzzles.service';
+import { CreatePuzzleService } from './providers/create-puzzle.service';
+import { CategoriesModule } from '../categories/categories.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Puzzle]),
+    CategoriesModule, // Import to use CategoriesService for category validation
+  ],
+  controllers: [PuzzlesController],
+  providers: [PuzzlesService, CreatePuzzleService],
+  exports: [PuzzlesService],
+})
+export class PuzzlesModule {}


### PR DESCRIPTION
## Summary

Implements the `POST /puzzles` API endpoint as specified in issue #165.

- Add `CategoriesModule` with Category entity and validation logic
- Add `PuzzlesModule` with controller, service, and domain provider
- Add TypeORM `@ManyToOne` relation between Puzzle and Category entities
- Auto-assign default points based on puzzle difficulty

Fixes #165

## New Files

| File | Purpose |
|------|---------|
| `src/categories/entities/category.entity.ts` | Category model with `id`, `name`, `isActive` |
| `src/categories/providers/find-category-by-id.service.ts` | Validates category exists and is active |
| `src/categories/providers/categories.service.ts` | Category service orchestrator |
| `src/categories/categories.module.ts` | Categories module |
| `src/puzzles/providers/create-puzzle.service.ts` | Domain logic for puzzle creation |
| `src/puzzles/providers/puzzles.service.ts` | Puzzles service orchestrator |
| `src/puzzles/controllers/puzzles.controller.ts` | HTTP endpoint handler |
| `src/puzzles/puzzles.module.ts` | Puzzles module |

## Modified Files

| File | Change |
|------|--------|
| `src/app.module.ts` | Added `CategoriesModule` and `PuzzlesModule` |
| `src/puzzles/entities/puzzle.entity.ts` | Added `@ManyToOne` relation to Category |

## API Endpoint

**`POST /puzzles`**

```json
{
  "question": "What is 2 + 2?",
  "options": ["3", "4", "5", "6"],
  "correctAnswer": "4",
  "difficulty": "BEGINNER",
  "categoryId": "valid-uuid-here",
  "timeLimit": 60
}
```

## Test Plan

## Testing

**Swagger UI:** `http://localhost:3000/api`

Navigate to the **puzzles** section and use the `POST /puzzles` endpoint to test.

| Test | Expected |
|------|----------|
| Valid request | 201 + puzzle with auto-assigned points |
| Invalid category | 404 "Category not found" |
| Invalid input | 400 with validation errors |