### PR TITLE
feat(frontend): add side navigation, placeholder pages for dashboard (closes #155)

### DIFF
--- a/frontend/app/categories/[slug]/page.tsx
+++ b/frontend/app/categories/[slug]/page.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+interface CategoryPageProps {
+  params: { slug: string };
+}
+
+const CategoryPage = ({ params }: CategoryPageProps) => {
+  const title = params.slug.replace(/-/g, " ");
+
+  return (
+    <div className="min-h-screen w-full bg-slate-950 text-slate-100 px-6 py-10">
+      <div className="mx-auto w-full max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/60 p-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+          Placeholder Route
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold text-white">
+          {title.charAt(0).toUpperCase() + title.slice(1)}
+        </h1>
+        <p className="mt-3 text-sm text-slate-400">
+          This page is a UI placeholder for the selected category.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default CategoryPage;

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,37 +1,103 @@
-'use client'
-import Button from "@/components/ui/Button";
-import { useRouter } from "next/navigation";
+'use client';
 
+import { useRouter } from "next/navigation";
+import DailyQuestCard from "@/components/dashboard/DailyQuestCard";
+import CategoryCard from "@/components/dashboard/CategoryCard";
+import Image from "next/image";
+import { Flame, Gem, User } from "lucide-react";
 
 const Dashboard = () => {
-
   const router = useRouter();
 
-  const handleLogout = () => {
-    // 1. Remove the token from client-side storage
-    localStorage.removeItem('accessToken'); 
+  const categories = [
+    {
+      icon: "🧩",
+      name: "Puzzles",
+      description: "Pattern Recognition",
+      userLevel: "Level 5",
+      slug: "puzzles",
+    },
+    {
+      icon: "💻",
+      name: "Coding",
+      description: "Algorithm and Data Structures",
+      userLevel: "Level 2",
+      slug: "coding",
+    },
+    {
+      icon: "⛓️",
+      name: "Blockchain",
+      description: "Crypto & Defi Concepts",
+      userLevel: "Level 2",
+      slug: "blockchain",
+    },
+  ];
 
-    // 2. Redirect the user
-    router.push('/auth/signin'); 
-  };
+  return (
+    <div className="min-h-screen w-full bg-[#0A0F1A] text-slate-100">
+      <header className="w-full border-b border-slate-800/80">
+        <div className="mx-auto flex w-full max-w-none flex-col gap-4 px-4 py-4 sm:max-w-6xl sm:flex-row sm:items-center sm:justify-between sm:px-6">
+          <div className="flex items-center gap-3">
+            <div className="relative h-10 w-10 overflow-hidden rounded-xl bg-slate-900/70">
+              <Image src="/logo.png" alt="Mind Block" fill className="object-contain" />
+            </div>
+            <span className="text-sm font-semibold text-slate-200">mind block</span>
+          </div>
 
-  return ( 
-    <div className='flex flex-row justify-around'>
-      Dashboard
-      <div className="">
-      {/* Sign In Button */}
-            <Button
-            onClick={handleLogout}
-              type="submit"
-              disabled={false}
-              className="w-full h-12 px-[10px] py-[14px] bg-[#3B82F6] hover:bg-[#2663C7] [box-shadow:0px_4px_0px_0px_#2663C7] text-white font-medium rounded-lg transition-colors mt-5"
-            >
-              { "Logout"}
-            </Button>
+          <div className="flex flex-wrap items-center gap-4 text-sm">
+            <div className="flex items-center gap-2 text-amber-300">
+              <Flame className="h-4 w-4" />
+              <span className="text-slate-200">3 Day Streak</span>
+            </div>
+            <div className="flex items-center gap-2 text-blue-300">
+              <Gem className="h-4 w-4" />
+              <span className="text-slate-200">1.1K Points</span>
+            </div>
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-700/70 text-slate-100">
+              <User className="h-4 w-4" />
+            </div>
+          </div>
+        </div>
+      </header>
 
-      </div>
+      <main className="mx-auto w-full max-w-none px-4 py-8 sm:max-w-6xl sm:px-6">
+        <div className="flex flex-col items-center gap-4">
+          <div className="flex items-center gap-6 text-xs text-slate-300">
+            <div className="flex items-center gap-2">
+              <Flame className="h-4 w-4 text-amber-300" />
+              <span>3 Day Streak</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Gem className="h-4 w-4 text-blue-300" />
+              <span>1.1K Points</span>
+            </div>
+          </div>
+          <DailyQuestCard
+            title="Daily Quest"
+            questionCount={5}
+            progressCurrent={2}
+            progressTotal={5}
+          />
+        </div>
+
+        <section className="mt-10">
+          <h2 className="text-base font-semibold text-white">Categories</h2>
+          <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-2">
+            {categories.map((category) => (
+              <CategoryCard
+                key={category.slug}
+                icon={category.icon}
+                name={category.name}
+                description={category.description}
+                userLevel={category.userLevel}
+                onClick={() => router.push(`/categories/${category.slug}`)}
+              />
+            ))}
+          </div>
+        </section>
+      </main>
     </div>
   );
-}
+};
 
 export default Dashboard;

--- a/frontend/app/feeds/page.tsx
+++ b/frontend/app/feeds/page.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+const FeedsPage = () => {
+  return (
+    <div className="min-h-screen w-full bg-slate-950 text-slate-100 px-6 py-10">
+      <div className="mx-auto w-full max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/60 p-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+          Placeholder Route
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold text-white">Feeds</h1>
+        <p className="mt-3 text-sm text-slate-400">
+          Updates from friends and the Mind Block community will appear here.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default FeedsPage;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ToastProvider } from '@/components/ui/ToastProvider';
+import SideNav from "@/components/SideNav";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,8 +30,10 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       > 
           <ToastProvider>
-            {/* <Navbar /> */}
-            {children}
+            <div className="min-h-screen w-full bg-[#0A0F1A] text-slate-100 flex flex-col md:flex-row">
+              <SideNav />
+              <main className="flex-1">{children}</main>
+            </div>
           </ToastProvider>
       </body>
     </html>

--- a/frontend/app/leaderboard/page.tsx
+++ b/frontend/app/leaderboard/page.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+const LeaderboardPage = () => {
+  return (
+    <div className="min-h-screen w-full bg-slate-950 text-slate-100 px-6 py-10">
+      <div className="mx-auto w-full max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/60 p-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+          Placeholder Route
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold text-white">Leaderboard</h1>
+        <p className="mt-3 text-sm text-slate-400">
+          This section will showcase top performers in the Mind Block community.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default LeaderboardPage;

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+const ProfilePage = () => {
+  return (
+    <div className="min-h-screen w-full bg-slate-950 text-slate-100 px-6 py-10">
+      <div className="mx-auto w-full max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/60 p-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+          Placeholder Route
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold text-white">Profile</h1>
+        <p className="mt-3 text-sm text-slate-400">
+          This page will contain your achievements, stats, and account settings.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/frontend/components/SideNav.tsx
+++ b/frontend/components/SideNav.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Home, Trophy, User, Bell } from "lucide-react";
+
+const navItems = [
+  { label: "Home", href: "/dashboard", icon: Home },
+  { label: "Leaderboard", href: "/leaderboard", icon: Trophy },
+  { label: "Profile", href: "/profile", icon: User },
+  { label: "Feeds", href: "/feeds", icon: Bell },
+];
+
+const SideNav = () => {
+  const pathname = usePathname();
+
+  return (
+    <aside className="w-full md:w-72 md:min-h-screen bg-[#0B1321] border-b md:border-b-0 md:border-r border-slate-800/80 px-4 py-4 sm:px-6 sm:py-6 flex md:flex-col items-center md:items-stretch gap-4 sm:gap-6">
+      <nav className="flex w-full flex-row md:flex-col justify-around md:justify-start gap-2">
+        {navItems.map((item) => {
+          const Icon = item.icon;
+          const isActive = pathname === item.href;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`flex items-center justify-center md:justify-start gap-3 rounded-xl px-3 py-3 text-sm font-medium transition ${
+                isActive
+                  ? "bg-blue-600/20 text-blue-200 shadow-inner"
+                  : "text-slate-300 hover:bg-slate-800/70 hover:text-slate-100"
+              }`}
+            >
+              <Icon className="h-4 w-4" />
+              <span className="hidden md:inline">{item.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+};
+
+export default SideNav;

--- a/frontend/components/dashboard/CategoryCard.tsx
+++ b/frontend/components/dashboard/CategoryCard.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import React from "react";
+import { ArrowRight } from "lucide-react";
+
+interface CategoryCardProps {
+  icon: React.ReactNode;
+  name: string;
+  description: string;
+  userLevel: string;
+  onClick: () => void;
+}
+
+const CategoryCard = ({
+  icon,
+  name,
+  description,
+  userLevel,
+  onClick,
+}: CategoryCardProps) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group w-full rounded-2xl border border-slate-800 bg-[#101B30] p-4 text-left transition hover:-translate-y-0.5 hover:border-blue-500/60 hover:bg-[#13213A]"
+    >
+      <div className="rounded-xl bg-[#1C335B] p-4 text-3xl text-slate-200">
+        {icon}
+      </div>
+      <div className="mt-4">
+        <p className="text-sm font-semibold text-white">{name}</p>
+        <p className="mt-1 text-xs text-slate-400">{description}</p>
+      </div>
+      <div className="mt-4 flex items-center justify-between">
+        <span className="text-xs text-slate-300">{userLevel}</span>
+        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-blue-500 text-white">
+          <ArrowRight className="h-4 w-4" />
+        </span>
+      </div>
+    </button>
+  );
+};
+
+export default CategoryCard;

--- a/frontend/components/dashboard/DailyQuestCard.tsx
+++ b/frontend/components/dashboard/DailyQuestCard.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { ArrowRight } from "lucide-react";
+
+interface DailyQuestCardProps {
+  title: string;
+  questionCount: number;
+  progressCurrent: number;
+  progressTotal: number;
+}
+
+const DailyQuestCard = ({
+  title,
+  questionCount,
+  progressCurrent,
+  progressTotal,
+}: DailyQuestCardProps) => {
+  const progressPercent = Math.min(
+    100,
+    Math.round((progressCurrent / progressTotal) * 100)
+  );
+
+  return (
+    <div className="w-full max-w-xl rounded-2xl border border-blue-500/30 bg-[#101B30] p-5 shadow-[0_0_30px_rgba(37,99,235,0.15)]">
+      <div className="flex items-center gap-4">
+        <div className="h-20 w-20 rounded-xl bg-[#1C335B]" />
+        <div className="flex-1">
+          <p className="text-sm font-semibold text-slate-200">{title}</p>
+          <p className="mt-1 text-xs text-slate-400">{questionCount} Questions</p>
+          <div className="mt-3">
+            <div className="flex items-center justify-between text-[11px] text-slate-400">
+              <span>Progress</span>
+              <span>{progressCurrent}/{progressTotal}</span>
+            </div>
+            <div className="mt-2 h-2 w-full rounded-full bg-slate-700/60">
+              <div
+                className="h-full rounded-full bg-blue-400"
+                style={{ width: `${progressPercent}%` }}
+              />
+            </div>
+          </div>
+        </div>
+        <button
+          type="button"
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-blue-500 text-white"
+        >
+          <ArrowRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DailyQuestCard;

--- a/frontend/components/dashboard/DashboardHeader.tsx
+++ b/frontend/components/dashboard/DashboardHeader.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+interface DashboardHeaderProps {
+  streakLabel: string;
+  pointsLabel: string;
+}
+
+const DashboardHeader = ({ streakLabel, pointsLabel }: DashboardHeaderProps) => {
+  return (
+    <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+      <div>
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">
+          Dashboard Home
+        </p>
+        <h1 className="mt-2 text-3xl font-semibold text-white sm:text-4xl">
+          Welcome back, Challenger.
+        </h1>
+        <p className="mt-2 text-sm text-slate-400">
+          Keep your momentum and unlock the next reward tier.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        <div className="flex items-center gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 px-4 py-3">
+          <span className="text-lg">🔥</span>
+          <div>
+            <p className="text-xs font-semibold text-slate-400">Streak</p>
+            <p className="text-sm font-semibold text-white">{streakLabel}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 px-4 py-3">
+          <span className="text-lg">⭐</span>
+          <div>
+            <p className="text-xs font-semibold text-slate-400">Points</p>
+            <p className="text-sm font-semibold text-white">{pointsLabel}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardHeader;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
feat(frontend): add side navigation, placeholder pages for dashboard (closes #155)

- Introduce SideNav component with navigation links to dashboard, leaderboard, profile, and feeds
- Add placeholder pages for categories, feeds, leaderboard, and profile
- Enhance dashboard page with category cards, daily quest card, and updated UI
- Update root layout to include side navigation
- Add new dashboard components: CategoryCard, DailyQuestCard, DashboardHeader
- Minor formatting updates to tsconfig.json for better structure
-  Mobile Responsive 