### PR TITLE
fix: Friends UI

### DIFF
--- a/backend/src/database/migrations/20250601204322-AddDifficultyAndCategoryToIQQuestions.ts
+++ b/backend/src/database/migrations/20250601204322-AddDifficultyAndCategoryToIQQuestions.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddDifficultyAndCategoryToIQQuestions20250601204322
-  implements MigrationInterface
-{
+export class AddDifficultyAndCategoryToIQQuestions20250601204322 implements MigrationInterface {
   name = 'AddDifficultyAndCategoryToIQQuestions20250601204322';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/backend/src/database/migrations/20250601204323-CreateDailyStreaksTable.ts
+++ b/backend/src/database/migrations/20250601204323-CreateDailyStreaksTable.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class CreateDailyStreaksTable20250601204323
-  implements MigrationInterface
-{
+export class CreateDailyStreaksTable20250601204323 implements MigrationInterface {
   name = 'CreateDailyStreaksTable20250601204323';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/backend/src/progress/providers/get-category-stats.provider.ts
+++ b/backend/src/progress/providers/get-category-stats.provider.ts
@@ -3,16 +3,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { FindOptionsWhere, Repository } from 'typeorm';
 import { UserProgress } from '../entities/progress.entity';
 
-interface CategoryStatsRaw {
-  categoryId: string;
-  totalAttempts: string;
-  correctAnswers: string;
-}
-
-interface CategoryNameRaw {
-  category_name: string;
-}
-
 @Injectable()
 export class GetCategoryStatsProvider {
   constructor(

--- a/backend/src/progress/providers/get-overall-stats.provider.ts
+++ b/backend/src/progress/providers/get-overall-stats.provider.ts
@@ -4,13 +4,6 @@ import { FindOptionsWhere, Repository } from 'typeorm';
 import { UserProgress } from '../entities/progress.entity';
 import { OverallStatsDto } from '../dtos/overall-stats.dto';
 
-interface OverallStatsRaw {
-  totalAttempts: string;
-  totalCorrect: string;
-  totalPointsEarned: string;
-  totalTimeSpent: string;
-}
-
 @Injectable()
 export class GetOverallStatsProvider {
   constructor(

--- a/backend/src/progress/providers/progress-calculation.provider.ts
+++ b/backend/src/progress/providers/progress-calculation.provider.ts
@@ -21,13 +21,6 @@ export interface ProgressCalculationResult {
   validation: AnswerValidationResult;
 }
 
-interface ProgressStatsRaw {
-  totalAttempts: string;
-  correctAttempts: string;
-  totalPoints: string;
-  averageTimeSpent: string;
-}
-
 @Injectable()
 export class ProgressCalculationProvider {
   constructor(

--- a/backend/src/puzzles/dtos/create-puzzle.dto.ts
+++ b/backend/src/puzzles/dtos/create-puzzle.dto.ts
@@ -20,9 +20,7 @@ import {
 } from '../enums/puzzle-difficulty.enum';
 
 @ValidatorConstraint({ name: 'correctAnswerInOptions', async: false })
-export class CorrectAnswerInOptionsConstraint
-  implements ValidatorConstraintInterface
-{
+export class CorrectAnswerInOptionsConstraint implements ValidatorConstraintInterface {
   validate(correctAnswer: string, args: ValidationArguments) {
     const object = args.object as CreatePuzzleDto;
     return object.options?.includes(correctAnswer) || false;
@@ -34,9 +32,7 @@ export class CorrectAnswerInOptionsConstraint
 }
 
 @ValidatorConstraint({ name: 'optionsMinimumLength', async: false })
-export class OptionsMinimumLengthConstraint
-  implements ValidatorConstraintInterface
-{
+export class OptionsMinimumLengthConstraint implements ValidatorConstraintInterface {
   validate(options: string[]) {
     return options?.length >= 2;
   }

--- a/backend/src/streak/providers/streaks.service.ts
+++ b/backend/src/streak/providers/streaks.service.ts
@@ -4,9 +4,7 @@ import { Streak } from '../entities/streak.entity';
 
 @Injectable()
 export class StreaksService {
-  constructor(
-    private readonly updateStreakProvider: UpdateStreakProvider,
-  ) {}
+  constructor(private readonly updateStreakProvider: UpdateStreakProvider) {}
 
   /**
    * Get user's current streak

--- a/frontend/app/auth/signup/page.tsx
+++ b/frontend/app/auth/signup/page.tsx
@@ -20,7 +20,6 @@ const SignUpPage = () => {
     isConnecting,
     isSigning,
     isLoggingIn,
-    error: walletError,
     connectAndLogin,
     clearError,
   } = useStellarWalletAuth();

--- a/frontend/app/friends/add/page.tsx
+++ b/frontend/app/friends/add/page.tsx
@@ -1,0 +1,15 @@
+export default function AddFriendsPage() {
+  return (
+    <div className="min-h-screen w-full bg-[#0A0F1A] px-4 py-10 text-slate-100 sm:px-6">
+      <div className="mx-auto w-full max-w-3xl rounded-3xl border border-[#CBD2D9]/15 bg-[#0F172A]/90 p-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#CBD2D9]">
+          Placeholder Route
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold text-[#F8FAFC]">Add Friends</h1>
+        <p className="mt-3 text-sm text-[#CBD2D9]">
+          Friend discovery will be added in a future backend-connected task.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/friends/friends-content.tsx
+++ b/frontend/app/friends/friends-content.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { FriendListItem } from "../../components/friends/FriendListItem";
+import { FriendsTab, FriendsTabs } from "../../components/friends/FriendsTabs";
+
+type Friend = {
+  id: string;
+  username: string;
+  avatar: string;
+};
+
+const followingFriends: Friend[] = [
+  { id: "f1", username: "Aaron", avatar: "/profileAvatar.svg" },
+  { id: "f2", username: "Nora", avatar: "/profileAvatar.svg" },
+  { id: "f3", username: "Tomi", avatar: "/profileAvatar.svg" },
+  { id: "f4", username: "Maya", avatar: "/profileAvatar.svg" },
+  { id: "f5", username: "Kareem", avatar: "/profileAvatar.svg" },
+];
+
+const followerFriends: Friend[] = [
+  { id: "r1", username: "Aisha", avatar: "/profileAvatar.svg" },
+  { id: "r2", username: "Daniel", avatar: "/profileAvatar.svg" },
+  { id: "r3", username: "Pearl", avatar: "/profileAvatar.svg" },
+  { id: "r4", username: "Ife", avatar: "/profileAvatar.svg" },
+  { id: "r5", username: "Levi", avatar: "/profileAvatar.svg" },
+];
+
+const parseTab = (value: string | null): FriendsTab =>
+  value === "followers" ? "followers" : "following";
+
+export default function FriendsPageContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const tabParam = searchParams.get("tab");
+  const defaultTab = parseTab(tabParam);
+  const [activeTab, setActiveTab] = useState<FriendsTab>(defaultTab);
+
+  useEffect(() => {
+    setActiveTab(parseTab(tabParam));
+  }, [tabParam]);
+
+  const friends = useMemo(
+    () => (activeTab === "following" ? followingFriends : followerFriends),
+    [activeTab]
+  );
+
+  const handleTabChange = (tab: FriendsTab) => {
+    setActiveTab(tab);
+    router.replace(`/friends?tab=${tab}`);
+  };
+
+  return (
+    <div className="min-h-screen w-full bg-[#0A0F1A] px-4 py-8 text-slate-100 sm:px-6">
+      <div className="mx-auto w-full max-w-3xl rounded-3xl border border-[#CBD2D9]/15 bg-[#0F172A]/90 p-5 shadow-[0_10px_25px_rgba(2,6,23,0.35)] sm:p-7">
+        <h1 className="text-[28px] font-semibold text-[#F8FAFC]">Friends</h1>
+
+        <FriendsTabs activeTab={activeTab} onTabChange={handleTabChange} />
+
+        <div className="mt-4 divide-y divide-[#CBD2D9]/15">
+          {friends.map((friend) => (
+            <FriendListItem
+              key={friend.id}
+              avatar={friend.avatar}
+              username={friend.username}
+              onClick={() => router.push(`/profile?user=${friend.username.toLowerCase()}`)}
+            />
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => router.push("/friends/add")}
+          className="mt-8 text-sm font-semibold text-[#3B82F6] transition-colors hover:text-[#60A5FA] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#3B82F6]"
+        >
+          Add Friends +
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/friends/page.tsx
+++ b/frontend/app/friends/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from "react";
+import FriendsPageContent from "./friends-content";
+
+export default function FriendsPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen w-full bg-[#0A0F1A]" />}>
+      <FriendsPageContent />
+    </Suspense>
+  );
+}

--- a/frontend/app/global-error.tsx
+++ b/frontend/app/global-error.tsx
@@ -5,10 +5,8 @@ import GenericErrorPage from '../components/error/GenericErrorPage';
 
 export default function GlobalError({
   error,
-  reset,
 }: {
   error: Error & { digest?: string };
-  reset: () => void;
 }) {
   useEffect(() => {
     // Log the error to an error reporting service

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Poppins, Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ToastProvider } from "@/components/ui/ToastProvider";
 import StoreProvider from "@/providers/storeProvider";
@@ -7,12 +7,6 @@ import CompletionFeatureProvider from "@/providers/CompletionFeatureProvider";
 import DashboardFeatureProvider from "@/providers/DashboardFeatureProvider";
 import ErrorBoundary from "@/components/error/ErrorBoundary";
 import { NetworkStatusProvider } from "@/providers/NetworkStatusProvider";
-
-const poppins = Poppins({
-  subsets: ["latin"],
-  weight: ["300", "400", "500", "600", "700"], 
-  variable: "--font-poppins",
-});
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -6,7 +6,6 @@
 
 
 
-import { LogOut } from "lucide-react";
 import Button from "@/components/Button";
 import { ProfileHeader } from "@/components/profile/ProfileHeader";
 import { ProfileOverview } from "@/components/profile/ProfileOverview";

--- a/frontend/app/quiz/page.tsx
+++ b/frontend/app/quiz/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useRef, useEffect } from "react";
 import { Nunito } from "next/font/google";
-import { MOCK_QUIZ } from "@/lib/Quiz_data";
 import { QuizHeader } from "@/components/quiz/QuizHeader";
 import { AnswerOption } from "@/components/quiz/AnswerOption";
 import { LevelComplete } from "@/components/quiz/LevelComplete";

--- a/frontend/app/test-case-demo/page.tsx
+++ b/frontend/app/test-case-demo/page.tsx
@@ -49,17 +49,15 @@ const TestCaseDemoPage: React.FC = () => {
         <div className="bg-gray-900 rounded-xl p-6 shadow-lg">
           <h2 className="text-lg font-semibold text-gray-200 mb-4">Challenge Solution</h2>
           
-          {/* Mock code editor */}
           <div className="bg-gray-850 border border-gray-700 rounded-md p-4 mb-6 min-h-[200px]">
             <div className="font-mono text-sm text-gray-300">
-              <div className="mb-2">// Your solution here...</div>
-              <div>function reverseWords(str) {'{'}</div>
-              <div className="ml-4">return str.trim().split(/\s+/).reverse().join(' ');</div>
-              <div>{'}'}</div>
+              <div className="mb-2">{`// Your solution here...`}</div>
+              <div>{`function reverseWords(str) {`}</div>
+              <div className="ml-4">{`return str.trim().split(/\\s+/).reverse().join(' ');`}</div>
+              <div>{`}`}</div>
             </div>
           </div>
           
-          {/* Test Case Panel */}
           <div>
             <h3 className="text-md font-medium text-gray-300 mb-3">Test Cases</h3>
             <TestCasePanel
@@ -73,8 +71,8 @@ const TestCaseDemoPage: React.FC = () => {
         <div className="mt-8 text-gray-400 text-sm">
           <p>Demo showing the test case panel with:</p>
           <ul className="list-disc pl-5 mt-2 space-y-1">
-            <li>Case 1: Success state (green checkmark + "Correct!")</li>
-            <li>Case 2: Error state (red X + "Wrong!" + error message)</li>
+            <li>{`Case 1: Success state (green checkmark + "Correct!")`}</li>
+            <li>{`Case 2: Error state (red X + "Wrong!" + error message)`}</li>
             <li>Case 3: Pending state (no validation status)</li>
             <li>Tab navigation with keyboard support</li>
             <li>Expand/collapse functionality</li>

--- a/frontend/components/coding/TestCaseTabs.tsx
+++ b/frontend/components/coding/TestCaseTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Plus } from 'lucide-react';
 
 interface TestCase {
@@ -21,17 +21,13 @@ const TestCaseTabs: React.FC<TestCaseTabsProps> = ({
   activeCase, 
   onTabChange 
 }) => {
-  const [focusedTab, setFocusedTab] = useState<number | null>(null);
-
   const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
     if (e.key === 'ArrowRight') {
       const nextIndex = (index + 1) % testCases.length;
       onTabChange(nextIndex);
-      setFocusedTab(nextIndex);
     } else if (e.key === 'ArrowLeft') {
       const prevIndex = (index - 1 + testCases.length) % testCases.length;
       onTabChange(prevIndex);
-      setFocusedTab(prevIndex);
     }
   };
 
@@ -48,6 +44,7 @@ const TestCaseTabs: React.FC<TestCaseTabsProps> = ({
           onClick={() => onTabChange(index)}
           onKeyDown={(e) => handleKeyDown(e, index)}
           tabIndex={0}
+          role="tab"
           aria-selected={activeCase === index}
         >
           Case {index + 1}

--- a/frontend/components/error/NotFoundPage.tsx
+++ b/frontend/components/error/NotFoundPage.tsx
@@ -30,10 +30,10 @@ const NotFoundPage = () => {
           </div>
           <h1 className="text-3xl font-bold text-purple-400 mb-4">Page Not Found</h1>
           <p className="text-gray-300 mb-2">
-            Oops! The page you're looking for doesn't exist.
+            {`Oops! The page you're looking for doesn't exist.`}
           </p>
           <p className="text-gray-400 text-sm">
-            It might have been moved, deleted, or the URL might be incorrect.
+            {`It might have been moved, deleted, or the URL might be incorrect.`}
           </p>
         </div>
 

--- a/frontend/components/error/OfflinePage.tsx
+++ b/frontend/components/error/OfflinePage.tsx
@@ -38,11 +38,11 @@ const OfflinePage = () => {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           </div>
-          <h1 className="text-2xl font-bold text-yellow-400 mb-4">You're Offline</h1>
+          <h1 className="text-2xl font-bold text-yellow-400 mb-4">{`You're Offline`}</h1>
           <p className="text-gray-300 mb-2">
             {isOnline 
               ? "Connection restored!" 
-              : "It looks like you're not connected to the internet."}
+              : `It looks like you're not connected to the internet.`}
           </p>
           <p className="text-gray-400 text-sm">
             Check your network connection and try again.

--- a/frontend/components/friends/FriendListItem.tsx
+++ b/frontend/components/friends/FriendListItem.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+import Image from "next/image";
+
+interface FriendListItemProps {
+  avatar: string;
+  username: string;
+  onClick: () => void;
+}
+
+export function FriendListItem({ avatar, username, onClick }: FriendListItemProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center justify-between gap-3 rounded-xl px-1 py-4 text-left transition-colors hover:bg-[#1E293B]/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#3B82F6]"
+      aria-label={`Open ${username}'s profile`}
+    >
+      <div className="flex items-center gap-3">
+        <div className="relative h-11 w-11 overflow-hidden rounded-full border border-[#CBD2D9]/20 bg-[#0B172A]">
+          <Image
+            src={avatar}
+            alt={username}
+            fill
+            sizes="44px"
+            className="object-cover"
+          />
+        </div>
+        <span className="text-[16px] font-semibold text-[#F8FAFC]">{username}</span>
+      </div>
+
+      <ChevronRight className="h-5 w-5 text-[#CBD2D9]" />
+    </button>
+  );
+}

--- a/frontend/components/friends/FriendsTabs.tsx
+++ b/frontend/components/friends/FriendsTabs.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+export type FriendsTab = "following" | "followers";
+
+interface FriendsTabsProps {
+  activeTab: FriendsTab;
+  onTabChange: (tab: FriendsTab) => void;
+}
+
+export function FriendsTabs({ activeTab, onTabChange }: FriendsTabsProps) {
+  const tabs: FriendsTab[] = ["following", "followers"];
+
+  return (
+    <div
+      className="mt-6 grid grid-cols-2 rounded-2xl border border-[#CBD2D9]/20 bg-[#0F172A] p-1"
+      role="tablist"
+      aria-label="Friends Tabs"
+    >
+      {tabs.map((tab) => {
+        const isActive = tab === activeTab;
+        const label = tab === "following" ? "Following" : "Followers";
+
+        return (
+          <button
+            key={tab}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onTabChange(tab)}
+            className={`rounded-xl px-3 py-3 text-sm font-semibold transition-colors ${
+              isActive
+                ? "bg-[#3B82F6] text-white"
+                : "text-[#CBD2D9] hover:bg-[#1E293B] hover:text-[#F8FAFC]"
+            }`}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/components/profile/AchievementSection.tsx
+++ b/frontend/components/profile/AchievementSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import Image from "next/image";
 import { AchievementCard } from "./AchievementCard";
 
 interface Achievement {
@@ -26,9 +27,11 @@ const iconSrcMap: Record<AchievementIcon, string> = {
 
 function AchievementIconImg({ name }: { name: AchievementIcon }) {
   return (
-    <img
+    <Image
       src={iconSrcMap[name]}
       alt={name}
+      width={48}
+      height={48}
       className="h-12 w-12"
       loading="lazy"
     />

--- a/frontend/components/profile/ProfileOverview.tsx
+++ b/frontend/components/profile/ProfileOverview.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { StatCard } from "./StatCard";
 
 interface ProfileOverviewProps {
@@ -50,7 +51,7 @@ export function ProfileOverview({
             key={stat.label}
             icon={
               <div className=" h-10 w-10 items-center justify-center">
-                <img src={stat.iconSrc} className="h-7 w-7" alt={stat.iconAlt} />
+                <Image src={stat.iconSrc} width={28} height={28} className="h-7 w-7" alt={stat.iconAlt} />
               </div>
             }
             value={stat.value}

--- a/frontend/features/completion/completion.context.tsx
+++ b/frontend/features/completion/completion.context.tsx
@@ -33,8 +33,9 @@ export const CompletionProvider: React.FC<{ children: React.ReactNode }> = ({ ch
     try {
       const data = await fetchUserStats();
       setStats(data);
-    } catch (err: any) {
-      setError(err.message || 'Failed to fetch stats');
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to fetch stats';
+      setError(errorMessage);
     }
   }, []);
 
@@ -46,8 +47,9 @@ export const CompletionProvider: React.FC<{ children: React.ReactNode }> = ({ ch
       await apiClaimPoints();
       setIsSuccess(true);
       await refreshStats();
-    } catch (err: any) {
-      setError(err.message || 'Failed to claim points');
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to claim points';
+      setError(errorMessage);
     } finally {
       setIsClaiming(false);
     }

--- a/frontend/features/dashboard/dashboard.context.tsx
+++ b/frontend/features/dashboard/dashboard.context.tsx
@@ -109,8 +109,9 @@ export const DashboardProvider: React.FC<DashboardProviderProps> = ({
         stats,
         categories,
       });
-    } catch (err: any) {
-      setError(err.message || "Failed to fetch dashboard data");
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : "Failed to fetch dashboard data";
+      setError(errorMessage);
       // Set default data on error
       setData({
         stats: defaultStats,

--- a/frontend/hooks/useStellarWalletAuth.ts
+++ b/frontend/hooks/useStellarWalletAuth.ts
@@ -9,8 +9,6 @@ import { fetchNonce, submitWalletLogin } from '../lib/stellar/api';
 import { useAppDispatch } from '../lib/reduxHooks';
 import { walletLoginSuccess, walletLoginFailure } from '../lib/features/auth/authSlice';
 
-const AUTH_MESSAGE = 'Sign this message to authenticate with Mindblock.';
-
 export function useStellarWalletAuth() {
   const dispatch = useAppDispatch();
   const [state, setState] = useState<WalletAuthState>({
@@ -144,7 +142,7 @@ export function useStellarWalletAuth() {
         throw error;
       }
     },
-    [clearError, setError]
+    [clearError, setError, dispatch]
   );
 
   /**

--- a/frontend/lib/errorLogger.ts
+++ b/frontend/lib/errorLogger.ts
@@ -1,6 +1,6 @@
 // Error logging utility for the mindBlock app
 export class ErrorLogger {
-  static logError(error: Error, context?: string, extraData?: Record<string, any>) {
+  static logError(error: Error, context?: string, extraData?: Record<string, unknown>) {
     // In development, always log to console
     if (process.env.NODE_ENV === 'development') {
       console.group('Error Logger');
@@ -35,13 +35,13 @@ export class ErrorLogger {
     );
   }
 
-  static logNetworkError(error: any, context?: string) {
+  static logNetworkError(error: unknown, context?: string) {
     this.logError(
-      new Error(`Network Error: ${error?.message || 'Unknown network error'}`),
+      new Error(`Network Error: ${error instanceof Error ? error.message : 'Unknown network error'}`),
       context,
       { 
-        errorType: error?.constructor?.name,
-        details: error?.toString?.() || error
+        errorType: error instanceof Error ? error.constructor?.name : typeof error,
+        details: error instanceof Error ? error.toString?.() : String(error)
       }
     );
   }

--- a/frontend/lib/features/auth/authSlice.ts
+++ b/frontend/lib/features/auth/authSlice.ts
@@ -33,7 +33,7 @@ const initialState: AuthState = {
 // Async thunks
 export const loginStart = createAsyncThunk(
   'auth/loginStart',
-  async (_, { rejectWithValue }) => {
+  async () => {
     // This is a placeholder for future email/password login
     // For now, this will be used with wallet authentication
     return null;
@@ -52,7 +52,7 @@ export const restoreSession = createAsyncThunk(
       // TODO: Validate token with backend and fetch user data
       // For now, just return the token
       return { token };
-    } catch (error) {
+    } catch {
       localStorage.removeItem('accessToken');
       return rejectWithValue('Session expired');
     }
@@ -69,7 +69,7 @@ export const refreshToken = createAsyncThunk(
         throw new Error('No token to refresh');
       }
       return { token };
-    } catch (error) {
+    } catch {
       localStorage.removeItem('accessToken');
       return rejectWithValue('Failed to refresh token');
     }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,4 @@
-export default {
+const config = {
   theme: {
     extend: {
       fontFamily: {
@@ -8,3 +8,5 @@ export default {
   },
   plugins: [],
 };
+
+export default config;


### PR DESCRIPTION
Closes #221 

This PR implements the Friends UI (Following/Followers) as a fully frontend, UI-only feature, based on the provided design direction and existing app layout.

What was fixed
Added a new Friends page route:

page.tsx
Renders inside the existing layout (side nav/top nav untouched).
Adds page title: Friends.
Uses mocked data only (no API/backend calls).
Implemented tab switcher for:

Following
Followers
Active tab is visually distinct.
Switching tabs updates the displayed mocked list.
Supports query-param driven state:
/friends?tab=following
/friends?tab=followers
Keeps tab state synced with URL updates.
Added reusable friends components:

FriendsTabs.tsx
Reusable, typed tab component.
FriendListItem.tsx
Reusable list row with props:
avatar
username
onClick
Entire row is clickable.
Chevron/right-arrow included.
Divider behavior handled by parent list container.
Added Add Friends action and route:

Bottom CTA text: Add Friends +
Uses Next.js router navigation to /friends/add
Placeholder page added:
page.tsx
Confirmed required access point from Profile:

Existing links in ProfileHeader route users correctly to:
/friends?tab=following
/friends?tab=followers
Scope and constraints respected
UI-only implementation
No backend integration
No endpoint consumption
Mocked/temporary constants used for list data
Reusable and composable component structure
Responsive behavior maintained (desktop-first, mobile-friendly)