### PR TITLE
feat: Create individual puzzle detail page with header, info card, an…

### DIFF
--- a/frontend/app/puzzles/[id]/page.tsx
+++ b/frontend/app/puzzles/[id]/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import React, { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { usePuzzle } from "@/hooks/usePuzzles";
+import HintsSection from "@/components/puzzles/HintsSection";
+import PuzzleHeader from "@/components/puzzles/PuzzleHeader";
+import PuzzleInfoCard from "@/components/puzzles/PuzzleInfoCard";
+
+export default function PuzzleDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const puzzleId = params.id as string;
+  const [showHints, setShowHints] = useState(false);
+
+  const { data: puzzle, isLoading, error } = usePuzzle(puzzleId);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-slate-950 text-slate-100 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500 mx-auto mb-4"></div>
+          <p>Loading puzzle...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !puzzle) {
+    return (
+      <div className="min-h-screen bg-slate-950 text-slate-100 flex items-center justify-center">
+        <div className="text-center">
+          <h2 className="text-2xl font-bold text-red-500 mb-4">Error</h2>
+          <p className="text-slate-400 mb-6">Failed to load puzzle details</p>
+          <button
+            onClick={() => router.back()}
+            className="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold transition-colors"
+          >
+            Go Back
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100 px-4 py-8">
+      <div className="mx-auto max-w-4xl">
+        <PuzzleHeader puzzleTitle={puzzle.title} />
+
+        <main className="space-y-6 mt-8">
+          <PuzzleInfoCard puzzle={puzzle} />
+
+          <div className="space-y-4">
+            <button
+              onClick={() => setShowHints(!showHints)}
+              className="w-full py-3 px-6 bg-slate-800 hover:bg-slate-700 rounded-lg font-semibold transition-colors text-left"
+            >
+              {showHints ? "Hide Hints" : "Show Hints"}
+            </button>
+            {showHints && <HintsSection />}
+          </div>
+
+          <button
+            onClick={() => router.push(`/puzzles/${puzzle.id}/solve`)}
+            style={{ boxShadow: `0 4px 0 0 #1e40af` }}
+            className="w-full h-12 bg-blue-600 hover:bg-blue-700 rounded-lg font-bold text-white transition-all active:translate-y-1"
+          >
+            Start Puzzle
+          </button>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/puzzles/page.tsx
+++ b/frontend/app/puzzles/page.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const page = () => {
+  return (
+    <div>page</div>
+  )
+}
+
+export default page

--- a/frontend/components/puzzles/HintsSection.tsx
+++ b/frontend/components/puzzles/HintsSection.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import React, { useState } from "react";
+
+const MOCK_HINTS = [
+  "Consider breaking down the problem into smaller parts.",
+  "Think about edge cases and boundary conditions.",
+  "Review the input constraints carefully.",
+];
+
+export default function HintsSection() {
+  const [revealedHints, setRevealedHints] = useState<number[]>([]);
+
+  const toggleHint = (index: number) => {
+    setRevealedHints((prev) =>
+      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index],
+    );
+  };
+
+  return (
+    <div className="space-y-3 rounded-xl border border-slate-700 bg-slate-900/60 p-6">
+      <div className="flex items-start gap-2">
+        <span className="text-xl">💡</span>
+        <div className="flex-1">
+          <h3 className="font-semibold text-slate-200 mb-1">Hints Available</h3>
+          <p className="text-xs text-slate-400">
+            {MOCK_HINTS.length} hints available • Each hint used deducts 2 XP
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-3 mt-4">
+        {MOCK_HINTS.map((hint, index) => (
+          <button
+            key={index}
+            onClick={() => toggleHint(index)}
+            className="w-full text-left p-4 rounded-lg border border-slate-600 bg-slate-800 hover:bg-slate-750 transition-colors group"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <span className="font-semibold text-slate-300 text-sm">
+                Hint {index + 1}
+              </span>
+              <span className="text-slate-400 group-hover:text-slate-200 transition-colors">
+                {revealedHints.includes(index) ? "−" : "+"}
+              </span>
+            </div>
+
+            {revealedHints.includes(index) && (
+              <p className="mt-3 text-slate-300 text-sm leading-relaxed">
+                {hint}
+              </p>
+            )}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-4 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
+        <p className="text-xs text-amber-400 flex items-start gap-2">
+          <span className="text-sm mt-0.5">⚠️</span>
+          <span>
+            Using hints will reduce your XP reward for solving this puzzle.
+          </span>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/puzzles/PuzzleHeader.tsx
+++ b/frontend/components/puzzles/PuzzleHeader.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React from "react";
+import { useRouter } from "next/navigation";
+
+interface PuzzleHeaderProps {
+  puzzleTitle: string;
+}
+
+export default function PuzzleHeader({ puzzleTitle }: PuzzleHeaderProps) {
+  const router = useRouter();
+
+  return (
+    <div className="space-y-4">
+      {/* Back Button */}
+      <button
+        onClick={() => router.back()}
+        className="flex items-center gap-2 text-slate-400 hover:text-slate-200 transition-colors font-semibold"
+      >
+        <span className="text-xl">←</span>
+        Back
+      </button>
+
+      {/* Breadcrumb */}
+      <nav className="flex items-center gap-2 text-sm text-slate-400">
+        <button
+          onClick={() => router.push("/puzzles")}
+          className="hover:text-slate-200 transition-colors"
+        >
+          Puzzles
+        </button>
+        <span>/</span>
+        <span className="text-slate-200">{puzzleTitle}</span>
+      </nav>
+
+      {/* Title */}
+      <h1 className="text-4xl font-bold text-white mt-6">{puzzleTitle}</h1>
+    </div>
+  );
+}

--- a/frontend/components/puzzles/PuzzleInfoCard.tsx
+++ b/frontend/components/puzzles/PuzzleInfoCard.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import React from "react";
+import { Puzzle } from "@/lib/types/puzzles";
+
+interface PuzzleInfoCardProps {
+  puzzle: Puzzle;
+}
+
+const difficultyConfig = {
+  easy: { color: "bg-emerald-500/20 text-emerald-400", stars: "★☆☆" },
+  medium: { color: "bg-yellow-500/20 text-yellow-400", stars: "★★☆" },
+  hard: { color: "bg-rose-500/20 text-rose-400", stars: "★★★" },
+};
+
+const typeConfig = {
+  logic: { icon: "🧠", label: "Logic Puzzle" },
+  coding: { icon: "💻", label: "Coding Challenge" },
+  blockchain: { icon: "⛓️", label: "Blockchain" },
+};
+
+export default function PuzzleInfoCard({ puzzle }: PuzzleInfoCardProps) {
+  const difficulty = puzzle.difficulty as keyof typeof difficultyConfig;
+  const type = puzzle.type as keyof typeof typeConfig;
+  const diffConfig = difficultyConfig[difficulty];
+  const typeConfig_ = typeConfig[type];
+  const pointsReward =
+    difficulty === "easy" ? 10 : difficulty === "medium" ? 25 : 50;
+
+  return (
+    <div className="rounded-xl border border-slate-700 bg-slate-900/60 p-8 space-y-6">
+      {/* Description */}
+      <div>
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-slate-400 mb-2">
+          Description
+        </h2>
+        <p className="text-base text-slate-300 leading-relaxed">
+          {puzzle.description}
+        </p>
+      </div>
+
+      {/* Info Grid */}
+      <div className="grid grid-cols-2 gap-6 md:grid-cols-4">
+        {/* Type */}
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Type
+          </p>
+          <div className="flex items-center gap-2">
+            <span className="text-xl">{typeConfig_.icon}</span>
+            <span className="font-semibold text-slate-200">
+              {typeConfig_.label}
+            </span>
+          </div>
+        </div>
+
+        {/* Difficulty */}
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Difficulty
+          </p>
+          <div className="flex items-center gap-2">
+            <span
+              className={`px-3 py-1 rounded-full text-sm font-bold ${diffConfig.color}`}
+            >
+              {diffConfig.stars}
+            </span>
+            <span className="capitalize font-semibold text-slate-200">
+              {difficulty}
+            </span>
+          </div>
+        </div>
+
+        {/* Time Limit */}
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Time Limit
+          </p>
+          <p className="font-semibold text-slate-200">
+            {puzzle.timeLimit ? `${puzzle.timeLimit} mins` : "No limit"}
+          </p>
+        </div>
+
+        {/* Points Reward */}
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+            XP Reward
+          </p>
+          <p className="font-semibold text-yellow-400">+{pointsReward} XP</p>
+        </div>
+      </div>
+
+      {/* Category Badge */}
+      {puzzle.categoryId && (
+        <div className="pt-4 border-t border-slate-700">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">
+            Category
+          </p>
+          <span className="inline-block px-4 py-2 bg-blue-500/20 text-blue-300 rounded-full text-sm font-semibold">
+            {puzzle.categoryId}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@reduxjs/toolkit": "^2.11.2",
     "@stellar/freighter-api": "^6.0.1",
+    "@tanstack/react-query": "^5.90.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.542.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,7 +241,7 @@
     },
     "backend/node_modules/@swc/core": {
       "version": "1.13.5",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -720,6 +720,7 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@reduxjs/toolkit": "^2.11.2",
         "@stellar/freighter-api": "^6.0.1",
+        "@tanstack/react-query": "^5.90.21",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.542.0",
@@ -4623,7 +4624,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4640,7 +4640,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4657,7 +4656,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4674,7 +4672,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4691,7 +4688,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4708,7 +4704,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4725,7 +4720,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4742,7 +4736,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4759,7 +4752,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4776,7 +4768,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4790,7 +4781,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
@@ -4806,7 +4797,7 @@
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"


### PR DESCRIPTION
## 🎯 Objective
Create the individual puzzle detail page with full puzzle view including description, hints, and start button.

## 📝 Changes
- **frontend/app/puzzles/[id]/page.tsx** - Main detail page with dynamic routing
  - Fetches puzzle data using `usePuzzle` hook
  - Displays title, description, type, difficulty, time limit, and category
  - Includes collapsible hints section
  - "Start Puzzle" button routes to solve page

- **frontend/components/puzzle/PuzzleHeader.tsx** - Header with navigation
  - Back button for returning to previous page
  - Breadcrumb navigation: Puzzles > Puzzle Name
  - Main puzzle title display

- **frontend/components/puzzle/PuzzleInfoCard.tsx** - Comprehensive info display
  - Puzzle description
  - Type indicator with emoji (🧠 Logic, 💻 Coding, ⛓️ Blockchain)
  - Difficulty level with stars (★☆☆ to ★★★)
  - Time limit (if applicable)
  - XP reward preview (difficulty-based: 10/25/50)
  - Category badge

- **frontend/components/puzzle/HintsSection.tsx** - Collapsible hints
  - Expandable/collapsible hints (mock data)
  - Hint reveal with toggle animations
  - Warning about XP penalty for using hints

## 🎨 Design
- Matches existing dark theme (slate-950 background)
- Dark card design on slate-900/60 background with slate-700 borders
- Consistent with quiz page styling patterns
- Responsive grid layout for info cards

## ✅ Completed Requirements
- [x] Create puzzle detail page with dynamic [id] routing
- [x] Display: title, description, type, difficulty, time limit
- [x] Category badge
- [x] "Start Puzzle" button
- [x] Puzzle header with back button and breadcrumb
- [x] Puzzle info card with all metadata
- [x] Difficulty indicator with stars
- [x] Estimated time and XP reward
- [x] Collapsible hints section with penalty warning

## 🔗 Dependencies
- Requires: Puzzle List API Integration - Base Setup
- Uses: `usePuzzle` hook from existing API layer

closes #266 