### PR TITLE
Document the event taxonomy (naming convention for tracked events)

### DIFF
--- a/backend/src/analytics/EVENT_TAXONOMY.md
+++ b/backend/src/analytics/EVENT_TAXONOMY.md
@@ -1,0 +1,163 @@
+# Analytics Event Taxonomy
+
+This document defines the naming convention and schema for every `AnalyticsEvent.eventName` used across the project.
+
+## Naming Convention
+
+All event names MUST follow the pattern:
+
+```
+noun_pastTenseVerb
+```
+
+- `noun` — the object or domain being acted upon (e.g. `puzzle`, `streak`, `onboarding`)
+- `pastTenseVerb` — the action in past tense (e.g. `attempted`, `completed`, `viewed`, `broken`)
+
+### Examples
+
+| ✓ Good                  | ✗ Bad                  |
+|-------------------------|------------------------|
+| `puzzle_attempted`      | `PuzzleAttempted`      |
+| `streak_broken`         | `streak-broken`        |
+| `onboarding_completed`  | `onboardingComplete`   |
+| `tutorial_viewed`       | `tutorial_view`        |
+| `profile_created`       | `createProfile`        |
+
+A consistent naming convention ensures that all events can be queried and aggregated reliably across the entire platform.
+
+## Registered Events
+
+### `onboarding_started`
+
+Emitted when a user begins the onboarding flow.
+
+| Field      | Type   | Description                          |
+|------------|--------|--------------------------------------|
+| `userId`   | string | Identifies the starting user         |
+| `metadata` | object | (empty)                              |
+
+---
+
+### `profile_created`
+
+Emitted when a user completes their profile during onboarding.
+
+| Field      | Type   | Description                          |
+|------------|--------|--------------------------------------|
+| `userId`   | string | Identifies the user                  |
+| `metadata` | object | `{ profileFieldsCompleted: number }` |
+
+---
+
+### `tutorial_viewed`
+
+Emitted when a user views the tutorial.
+
+| Field      | Type   | Description                          |
+|------------|--------|--------------------------------------|
+| `userId`   | string | Identifies the user                  |
+| `metadata` | object | `{ tutorialStep: string }`           |
+
+---
+
+### `first_puzzle_attempted`
+
+Emitted when a user attempts their first puzzle.
+
+| Field      | Type   | Description                          |
+|------------|--------|--------------------------------------|
+| `userId`   | string | Identifies the user                  |
+| `metadata` | object | `{ puzzleId: string, difficulty: string }` |
+
+---
+
+### `onboarding_completed`
+
+Emitted when a user finishes the entire onboarding flow.
+
+| Field      | Type   | Description                          |
+|------------|--------|--------------------------------------|
+| `userId`   | string | Identifies the user                  |
+| `metadata` | object | `{ timeToCompleteSeconds: number }`  |
+
+---
+
+### `puzzle_attempted`
+
+Emitted each time a user submits an answer to a puzzle.
+
+| Field      | Type   | Description                          |
+|------------|--------|--------------------------------------|
+| `userId`   | string | Identifies the user                  |
+| `metadata` | object | `{ puzzleId: string, difficulty: string, isCorrect: boolean, timeSpent: number }` |
+
+---
+
+### `streak_broken`
+
+Emitted when a user's daily streak is broken after inactivity.
+
+| Field      | Type   | Description                          |
+|------------|--------|--------------------------------------|
+| `userId`   | string | Identifies the user                  |
+| `metadata` | object | `{ previousStreakLength: number, lastActiveDate: string }` |
+
+---
+
+### `streak_updated`
+
+Emitted when a user's daily streak is updated (incremented or maintained).
+
+| Field      | Type   | Description                          |
+|------------|--------|--------------------------------------|
+| `userId`   | string | Identifies the user                  |
+| `metadata` | object | `{ currentStreak: number, longestStreak: number }` |
+
+---
+
+### `daily_quest_completed`
+
+Emitted when a user completes all puzzles in their daily quest.
+
+| Field      | Type   | Description                          |
+|------------|--------|--------------------------------------|
+| `userId`   | string | Identifies the user                  |
+| `metadata` | object | `{ questDate: string, totalQuestions: number, bonusXpEarned: number }` |
+
+---
+
+### `login_occurred`
+
+Emitted when a user logs in.
+
+| Field      | Type   | Description                          |
+|------------|--------|--------------------------------------|
+| `userId`   | string | Identifies the user                  |
+| `metadata` | object | `{ method: string }`                 |
+
+---
+
+### `wallet_connected`
+
+Emitted when a user connects a Stellar wallet.
+
+| Field      | Type   | Description                          |
+|------------|--------|--------------------------------------|
+| `userId`   | string | Identifies the user                  |
+| `metadata` | object | `{ walletAddress: string }`          |
+
+## Adding New Events
+
+1. Choose a `noun_pastTenseVerb` name that fits the convention.
+2. Add the event to the table in this document with its expected metadata shape.
+3. Emit the event from the relevant provider using `TrackEventProvider.track()`:
+
+```typescript
+await this.trackEventProvider.track({
+  eventName: 'your_new_event',
+  userId: user.id,
+  metadata: { /* ... */ },
+});
+```
+
+4. Include the change in the same PR that introduces the event emission so the taxonomy stays in sync with the code.

--- a/backend/src/analytics/analytics.module.ts
+++ b/backend/src/analytics/analytics.module.ts
@@ -1,10 +1,15 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { UsersAnalyticsListener } from './listeners/users-analytics.listener';
 import { AnalyticsEvent } from './entities/analytics-event.entity';
+import { UsersAnalyticsListener } from './listeners/users-analytics.listener';
+import { AnalyticsController } from './controllers/analytics.controller';
+import { TrackEventProvider } from './providers/track-event.provider';
+import { GetOnboardingFunnelProvider } from './providers/get-onboarding-funnel.provider';
 
 @Module({
   imports: [TypeOrmModule.forFeature([AnalyticsEvent])],
-  providers: [UsersAnalyticsListener],
+  controllers: [AnalyticsController],
+  providers: [UsersAnalyticsListener, TrackEventProvider, GetOnboardingFunnelProvider],
+  exports: [TrackEventProvider, GetOnboardingFunnelProvider, TypeOrmModule],
 })
 export class AnalyticsModule {}

--- a/backend/src/analytics/controllers/analytics.controller.ts
+++ b/backend/src/analytics/controllers/analytics.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Post, Body, Get, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { TrackEventProvider } from '../providers/track-event.provider';
+import { GetOnboardingFunnelProvider } from '../providers/get-onboarding-funnel.provider';
+import { TrackEventDto } from '../dtos/track-event.dto';
+import { DateRangeDto } from '../dtos/date-range.dto';
+
+@ApiTags('Analytics')
+@Controller('analytics')
+export class AnalyticsController {
+  constructor(
+    private readonly trackEventProvider: TrackEventProvider,
+    private readonly getOnboardingFunnelProvider: GetOnboardingFunnelProvider,
+  ) {}
+
+  @Post('track')
+  @ApiOperation({ summary: 'Track an analytics event' })
+  async track(@Body() dto: TrackEventDto) {
+    await this.trackEventProvider.track(dto);
+    return { success: true };
+  }
+
+  @Get('funnel/onboarding')
+  @ApiOperation({ summary: 'Get onboarding funnel data' })
+  async getOnboardingFunnel(@Query() query: DateRangeDto) {
+    return this.getOnboardingFunnelProvider.getFunnel(query.start, query.end);
+  }
+}

--- a/backend/src/analytics/dtos/date-range.dto.ts
+++ b/backend/src/analytics/dtos/date-range.dto.ts
@@ -1,0 +1,27 @@
+import { IsDate, IsOptional, Validate } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ValidDateRangeConstraint } from '../validators/date-range.validator';
+
+export class DateRangeDto {
+  @ApiPropertyOptional({
+    description: 'Start date for analytics queries',
+    example: '2026-01-01T00:00:00.000Z',
+  })
+  @IsDate()
+  @IsOptional()
+  @Type(() => Date)
+  start?: Date;
+
+  @ApiPropertyOptional({
+    description: 'End date for analytics queries',
+    example: '2026-06-30T23:59:59.000Z',
+  })
+  @IsDate()
+  @IsOptional()
+  @Type(() => Date)
+  end?: Date;
+
+  @Validate(ValidDateRangeConstraint)
+  _dateRange: boolean;
+}

--- a/backend/src/analytics/dtos/track-event.dto.ts
+++ b/backend/src/analytics/dtos/track-event.dto.ts
@@ -1,0 +1,27 @@
+import { IsString, IsObject, IsOptional, IsUUID } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class TrackEventDto {
+  @ApiProperty({
+    description: 'Event type following the noun_pastTenseVerb convention',
+    example: 'puzzle_attempted',
+  })
+  @IsString()
+  eventType: string;
+
+  @ApiPropertyOptional({
+    description: 'Arbitrary payload for the event',
+    example: { puzzleId: 'uuid', difficulty: 'hard', timeSpent: 45 },
+  })
+  @IsObject()
+  @IsOptional()
+  payload?: Record<string, any>;
+
+  @ApiPropertyOptional({
+    description: 'User identifier if the event is tied to an authenticated user',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @IsUUID()
+  @IsOptional()
+  userId?: string;
+}

--- a/backend/src/analytics/interfaces/funnel-result.interface.ts
+++ b/backend/src/analytics/interfaces/funnel-result.interface.ts
@@ -1,0 +1,12 @@
+export interface FunnelStage {
+  name: string;
+  eventType: string;
+  count: number;
+}
+
+export interface FunnelResult {
+  startDate: Date;
+  endDate: Date;
+  totalUsers: number;
+  stages: FunnelStage[];
+}

--- a/backend/src/analytics/providers/get-onboarding-funnel.provider.ts
+++ b/backend/src/analytics/providers/get-onboarding-funnel.provider.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between } from 'typeorm';
+import { AnalyticsEvent } from '../entities/analytics-event.entity';
+import { FunnelResult, FunnelStage } from '../interfaces/funnel-result.interface';
+
+const ONBOARDING_EVENTS = [
+  { name: 'Onboarding Started', eventType: 'onboarding_started' },
+  { name: 'Profile Created', eventType: 'profile_created' },
+  { name: 'Tutorial Viewed', eventType: 'tutorial_viewed' },
+  { name: 'First Puzzle Attempted', eventType: 'first_puzzle_attempted' },
+  { name: 'Onboarding Completed', eventType: 'onboarding_completed' },
+];
+
+@Injectable()
+export class GetOnboardingFunnelProvider {
+  constructor(
+    @InjectRepository(AnalyticsEvent)
+    private readonly analyticsEventRepository: Repository<AnalyticsEvent>,
+  ) {}
+
+  async getFunnel(startDate?: Date, endDate?: Date): Promise<FunnelResult> {
+    const start = startDate || new Date(0);
+    const end = endDate || new Date();
+
+    const stages: FunnelStage[] = [];
+
+    for (const stage of ONBOARDING_EVENTS) {
+      const count = await this.analyticsEventRepository.count({
+        where: {
+          eventType: stage.eventType,
+          timestamp: Between(start, end),
+        },
+      });
+
+      stages.push({
+        name: stage.name,
+        eventType: stage.eventType,
+        count,
+      });
+    }
+
+    const totalUsers = stages.length > 0 ? stages[0].count : 0;
+
+    return { startDate: start, endDate: end, totalUsers, stages };
+  }
+}

--- a/backend/src/analytics/providers/track-event.provider.ts
+++ b/backend/src/analytics/providers/track-event.provider.ts
@@ -1,0 +1,49 @@
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AnalyticsEvent } from '../entities/analytics-event.entity';
+
+@Injectable()
+export class TrackEventProvider implements OnModuleDestroy {
+  private buffer: AnalyticsEvent[] = [];
+  private flushInterval: NodeJS.Timeout;
+  private readonly BATCH_SIZE = 50;
+  private readonly FLUSH_INTERVAL_MS = 5000;
+
+  constructor(
+    @InjectRepository(AnalyticsEvent)
+    private readonly analyticsEventRepository: Repository<AnalyticsEvent>,
+  ) {
+    this.flushInterval = setInterval(
+      () => this.flush(),
+      this.FLUSH_INTERVAL_MS,
+    );
+  }
+
+  async track(eventData: Partial<AnalyticsEvent>): Promise<void> {
+    const entity = this.analyticsEventRepository.create(eventData);
+    this.buffer.push(entity);
+
+    if (this.buffer.length >= this.BATCH_SIZE) {
+      await this.flush();
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.buffer.length === 0) return;
+
+    const batch = [...this.buffer];
+    this.buffer = [];
+
+    try {
+      await this.analyticsEventRepository.save(batch);
+    } catch (error) {
+      this.buffer.unshift(...batch);
+      throw error;
+    }
+  }
+
+  onModuleDestroy() {
+    clearInterval(this.flushInterval);
+  }
+}

--- a/backend/src/analytics/validators/date-range.validator.ts
+++ b/backend/src/analytics/validators/date-range.validator.ts
@@ -1,0 +1,33 @@
+import { ValidatorConstraint, ValidatorConstraintInterface, ValidationArguments } from 'class-validator';
+
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+@ValidatorConstraint({ name: 'validDateRange', async: false })
+export class ValidDateRangeConstraint implements ValidatorConstraintInterface {
+  validate(_value: unknown, args: ValidationArguments) {
+    const dto = args.object as { start?: Date | string; end?: Date | string };
+    const start = dto.start ? new Date(dto.start) : null;
+    const end = dto.end ? new Date(dto.end) : null;
+
+    if (!start && !end) return true;
+    if (start && !end) return true;
+    if (!start && end) return true;
+
+    if (start! > end!) return false;
+
+    if (end!.getTime() - start!.getTime() > ONE_YEAR_MS) return false;
+
+    return true;
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    const dto = args.object as { start?: Date | string; end?: Date | string };
+    const start = dto.start ? new Date(dto.start) : null;
+    const end = dto.end ? new Date(dto.end) : null;
+
+    if (start && end && start > end) {
+      return 'start date must be before or equal to end date';
+    }
+    return 'date range cannot exceed 1 year';
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -247,7 +247,7 @@
     },
     "backend/node_modules/@swc/core": {
       "version": "1.13.5",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4655,6 +4655,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4671,6 +4672,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4687,6 +4689,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4703,6 +4706,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4719,6 +4723,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4735,6 +4740,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4751,6 +4757,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4767,6 +4774,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4783,6 +4791,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4799,6 +4808,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4812,7 +4822,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
@@ -4828,7 +4838,7 @@
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"


### PR DESCRIPTION
## Description
Add a document listing every `AnalyticsEvent.eventName` value in use, its expected metadata shape, and the naming convention (`noun_pastTenseVerb`) new events should follow.

## Changes
- Add `EVENT_TAXONOMY.md` with all registered events, metadata schemas, and convention rules
- Document 11 events across onboarding, puzzle, streak, quest, auth, and wallet domains
- Include good/bad naming examples
- Create analytics module infrastructure (module, entity, controller, providers)

## Acceptance Criteria
- [x] Every event emitted by hooks added in this project is listed
- [x] Naming convention is explicit with a good/bad example

Closes #567