### PR TITLE
feat(analytics): add churn risk scoring provider

### DIFF
--- a/backend/src/analytics/analytics.module.ts
+++ b/backend/src/analytics/analytics.module.ts
@@ -8,6 +8,7 @@ import { AnalyticsService } from './analytics.service';
 import { TrackEventProvider } from './providers/track-event.provider';
 import { GetOnboardingFunnelProvider } from './providers/get-onboarding-funnel.provider';
 import { GetRetentionCurveProvider } from './providers/get-retention-curve.provider';
+import { GetChurnRiskProvider } from './providers/get-churn-risk.provider';
 
 @Module({
   imports: [TypeOrmModule.forFeature([AnalyticsEvent, RetentionCohort])],
@@ -18,7 +19,15 @@ import { GetRetentionCurveProvider } from './providers/get-retention-curve.provi
     TrackEventProvider,
     GetOnboardingFunnelProvider,
     GetRetentionCurveProvider,
+    GetChurnRiskProvider,
   ],
-  exports: [AnalyticsService, TrackEventProvider, GetOnboardingFunnelProvider, GetRetentionCurveProvider, TypeOrmModule],
+  exports: [
+    AnalyticsService,
+    TrackEventProvider,
+    GetOnboardingFunnelProvider,
+    GetRetentionCurveProvider,
+    GetChurnRiskProvider,
+    TypeOrmModule,
+  ],
 })
 export class AnalyticsModule {}

--- a/backend/src/analytics/controllers/analytics.controller.ts
+++ b/backend/src/analytics/controllers/analytics.controller.ts
@@ -1,12 +1,22 @@
 import { Controller, Post, Body, Get, Query, UseGuards } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiExtraModels,
+  getSchemaPath,
+} from '@nestjs/swagger';
 import { TrackEventProvider } from '../providers/track-event.provider';
 import { GetOnboardingFunnelProvider } from '../providers/get-onboarding-funnel.provider';
 import { GetRetentionCurveProvider } from '../providers/get-retention-curve.provider';
+import { GetChurnRiskProvider } from '../providers/get-churn-risk.provider';
 import { AnalyticsService } from '../analytics.service';
 import { TrackEventDto } from '../dtos/track-event.dto';
 import { DateRangeDto } from '../dtos/date-range.dto';
-import { AnalyticsMetricResult } from '../dtos/analytics-metric-result.dto';
+import {
+  AnalyticsMetricResult,
+  ChurnRiskDataPoint,
+} from '../dtos/analytics-metric-result.dto';
 import { AnalyticsAdminGuard } from '../guards/analytics-admin.guard';
 
 @ApiTags('Analytics')
@@ -16,6 +26,7 @@ export class AnalyticsController {
     private readonly trackEventProvider: TrackEventProvider,
     private readonly getOnboardingFunnelProvider: GetOnboardingFunnelProvider,
     private readonly getRetentionCurveProvider: GetRetentionCurveProvider,
+    private readonly getChurnRiskProvider: GetChurnRiskProvider,
     private readonly analyticsService: AnalyticsService,
   ) {}
 
@@ -45,5 +56,31 @@ export class AnalyticsController {
   @ApiResponse({ status: 200, type: AnalyticsMetricResult })
   async getRetentionCurve(@Query() query: DateRangeDto) {
     return this.getRetentionCurveProvider.getRetentionCurve(query);
+  }
+
+  @Get('users/churn-risk')
+  @UseGuards(AnalyticsAdminGuard)
+  @ApiOperation({ summary: 'Get per-user churn risk scores (admin only)' })
+  @ApiExtraModels(AnalyticsMetricResult, ChurnRiskDataPoint)
+  @ApiResponse({
+    status: 200,
+    // AnalyticsMetricResult is generic, so `data` is described explicitly
+    // here — the class decorator alone would advertise RetentionDataPoint.
+    schema: {
+      allOf: [
+        { $ref: getSchemaPath(AnalyticsMetricResult) },
+        {
+          properties: {
+            data: {
+              type: 'array',
+              items: { $ref: getSchemaPath(ChurnRiskDataPoint) },
+            },
+          },
+        },
+      ],
+    },
+  })
+  async getChurnRisk(@Query() query: DateRangeDto) {
+    return this.getChurnRiskProvider.getChurnRisk(query);
   }
 }

--- a/backend/src/analytics/dtos/analytics-metric-result.dto.ts
+++ b/backend/src/analytics/dtos/analytics-metric-result.dto.ts
@@ -17,7 +17,75 @@ export class RetentionDataPoint {
   day30RetentionPct: number | null;
 }
 
-export class AnalyticsMetricResult {
+/** Risk band derived from `riskScore`. `null` when there is no usable baseline. */
+export type ChurnRiskBand = 'none' | 'low' | 'medium' | 'high';
+
+export class ChurnRiskDataPoint {
+  @ApiProperty({
+    example: 'user-123',
+    description: 'User the score belongs to',
+  })
+  userId: string;
+
+  @ApiProperty({
+    example: 78,
+    nullable: true,
+    description:
+      'Churn risk 0-100. Null when the user has too little history for a ' +
+      'baseline — deliberately not 0, which would read as "safe".',
+  })
+  riskScore: number | null;
+
+  @ApiProperty({
+    example: 'high',
+    nullable: true,
+    enum: ['none', 'low', 'medium', 'high'],
+  })
+  riskBand: ChurnRiskBand | null;
+
+  @ApiProperty({
+    example: 12.5,
+    description: 'Mean events per baseline bucket',
+  })
+  baselineMean: number;
+
+  @ApiProperty({
+    example: 2.1,
+    description:
+      'Std deviation of the baseline buckets. The drop is scored against this, ' +
+      'so a naturally spiky user needs a bigger drop to flag.',
+  })
+  baselineStdDev: number;
+
+  @ApiProperty({
+    example: 9,
+    description: 'Baseline buckets backing the score',
+  })
+  baselineBuckets: number;
+
+  @ApiProperty({ example: 1, description: 'Event count in the recent bucket' })
+  recentCount: number;
+
+  @ApiProperty({
+    example: 0,
+    description:
+      'Trailing buckets with no activity, most recent included. Reported but ' +
+      'not scored: this measures the drop, not sustained dormancy.',
+  })
+  consecutiveSilentBuckets: number;
+
+  @ApiProperty({
+    example: 0.92,
+    nullable: true,
+    description: 'Proportional drop from the baseline mean, for readability.',
+  })
+  dropRatio: number | null;
+
+  @ApiProperty({ example: false, description: 'History too short to score' })
+  insufficientBaseline: boolean;
+}
+
+export class AnalyticsMetricResult<T = RetentionDataPoint> {
   @ApiProperty({ example: '2024-01-01', description: 'Start of queried range' })
   startDate: string;
 
@@ -28,8 +96,8 @@ export class AnalyticsMetricResult {
   granularity: string;
 
   @ApiProperty({ type: [RetentionDataPoint] })
-  data: RetentionDataPoint[];
+  data: T[];
 
-  @ApiProperty({ example: 15, description: 'Total cohort rows returned' })
+  @ApiProperty({ example: 15, description: 'Total rows returned' })
   total: number;
 }

--- a/backend/src/analytics/entities/analytics-event.entity.ts
+++ b/backend/src/analytics/entities/analytics-event.entity.ts
@@ -1,6 +1,22 @@
-import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 
+/**
+ * Raw analytics event row.
+ *
+ * Indexes exist to serve two distinct access patterns:
+ *  - `['timestamp', 'userId']` — range scan over a reporting window, grouped by
+ *    user (churn risk, and any future per-user rollup job).
+ *  - `['userId', 'timestamp']` — a single user's history, ordered in time.
+ */
 @Entity('analytics_events')
+@Index(['timestamp', 'userId'])
+@Index(['userId', 'timestamp'])
 export class AnalyticsEvent {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/backend/src/analytics/providers/get-churn-risk.provider.spec.ts
+++ b/backend/src/analytics/providers/get-churn-risk.provider.spec.ts
@@ -1,0 +1,375 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AnalyticsEvent } from '../entities/analytics-event.entity';
+import { DateRangeDto } from '../dtos/date-range.dto';
+import {
+  ACTIVITY_EVENT_TYPES,
+  GetChurnRiskProvider,
+  MIN_BASELINE_BUCKETS,
+} from './get-churn-risk.provider';
+
+/** Day bucket key in the format the provider builds from `to_char`. */
+const day = (n: number) => `2024-01-${String(n).padStart(2, '0')}T00:00:00`;
+
+/** Raw rows as the grouped query would return them: one per (user, bucket). */
+const rowsFor = (userId: string, counts: Record<number, number>) =>
+  Object.entries(counts).map(([d, count]) => ({
+    userId,
+    bucket: day(Number(d)),
+    count,
+  }));
+
+/** 2024-01-01 → 2024-01-10 = 10 day buckets; day 10 is "recent", 1-9 baseline. */
+const TEN_DAYS: DateRangeDto = {
+  start: new Date('2024-01-01T00:00:00.000Z'),
+  end: new Date('2024-01-10T00:00:00.000Z'),
+  granularity: 'day',
+  _dateRange: true,
+};
+
+describe('GetChurnRiskProvider', () => {
+  let provider: GetChurnRiskProvider;
+  let qb: Record<string, jest.Mock>;
+  let mockRepo: { createQueryBuilder: jest.Mock };
+
+  beforeEach(async () => {
+    qb = {
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      addGroupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([]),
+    };
+    mockRepo = { createQueryBuilder: jest.fn(() => qb) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetChurnRiskProvider,
+        { provide: getRepositoryToken(AnalyticsEvent), useValue: mockRepo },
+      ],
+    }).compile();
+
+    provider = module.get<GetChurnRiskProvider>(GetChurnRiskProvider);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should be defined', () => {
+    expect(provider).toBeDefined();
+  });
+
+  describe('empty / no-data cases', () => {
+    it('returns an empty result when no events exist in the range', async () => {
+      qb.getRawMany.mockResolvedValue([]);
+
+      const result = await provider.getChurnRisk(TEN_DAYS);
+
+      expect(result.startDate).toBe('2024-01-01');
+      expect(result.endDate).toBe('2024-01-10');
+      expect(result.granularity).toBe('day');
+      expect(result.data).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('does not throw on an inverted range, and does not hit the DB', async () => {
+      const inverted: DateRangeDto = {
+        start: new Date('2024-01-10T00:00:00.000Z'),
+        end: new Date('2024-01-01T00:00:00.000Z'),
+        _dateRange: true,
+      };
+
+      await expect(provider.getChurnRisk(inverted)).resolves.toEqual(
+        expect.objectContaining({ data: [], total: 0 }),
+      );
+      expect(qb.getRawMany).not.toHaveBeenCalled();
+    });
+
+    it('returns empty for a single-day range — one bucket leaves no baseline', async () => {
+      const singleDay: DateRangeDto = {
+        start: new Date('2024-01-05T00:00:00.000Z'),
+        end: new Date('2024-01-05T00:00:00.000Z'),
+        granularity: 'day',
+        _dateRange: true,
+      };
+
+      const result = await provider.getChurnRisk(singleDay);
+
+      expect(result.data).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(qb.getRawMany).not.toHaveBeenCalled();
+    });
+
+    it('defaults granularity to "day" when not supplied', async () => {
+      const result = await provider.getChurnRisk({
+        start: new Date('2024-01-01T00:00:00.000Z'),
+        end: new Date('2024-01-10T00:00:00.000Z'),
+        _dateRange: true,
+      });
+
+      expect(result.granularity).toBe('day');
+    });
+  });
+
+  describe('scoring over a multi-day range', () => {
+    it('flags a steady user whose activity collapses', async () => {
+      // Baseline mean 10, std dev 0.5. Recent bucket drops to 2 -> ~16 sigma.
+      qb.getRawMany.mockResolvedValue(
+        rowsFor('steady', {
+          1: 10,
+          2: 10,
+          3: 10,
+          4: 10,
+          5: 10,
+          6: 10,
+          7: 10,
+          8: 11,
+          9: 9,
+          10: 2,
+        }),
+      );
+
+      const [point] = (await provider.getChurnRisk(TEN_DAYS)).data;
+
+      expect(point.userId).toBe('steady');
+      expect(point.baselineBuckets).toBe(9);
+      expect(point.baselineMean).toBe(10);
+      expect(point.baselineStdDev).toBe(0.5);
+      expect(point.recentCount).toBe(2);
+      expect(point.riskScore).toBe(100);
+      expect(point.riskBand).toBe('high');
+      expect(point.insufficientBaseline).toBe(false);
+    });
+
+    it('scores an identical drop far lower for a naturally spiky user', async () => {
+      // Both users land on recentCount = 2. The steady user's drop is many
+      // standard deviations; the spiky user's is well under one. This is the
+      // whole point of normalising by the user's own variance rather than by
+      // a raw frequency ratio.
+      qb.getRawMany.mockResolvedValue([
+        ...rowsFor('steady', {
+          1: 10,
+          2: 10,
+          3: 10,
+          4: 10,
+          5: 10,
+          6: 10,
+          7: 10,
+          8: 11,
+          9: 9,
+          10: 2,
+        }),
+        ...rowsFor('spiky', {
+          1: 2,
+          2: 18,
+          3: 1,
+          4: 20,
+          5: 3,
+          6: 17,
+          7: 2,
+          8: 19,
+          9: 1,
+          10: 2,
+        }),
+      ]);
+
+      const { data } = await provider.getChurnRisk(TEN_DAYS);
+      const steady = data.find((d) => d.userId === 'steady')!;
+      const spiky = data.find((d) => d.userId === 'spiky')!;
+
+      expect(steady.recentCount).toBe(spiky.recentCount);
+      expect(steady.riskScore).toBe(100);
+      expect(spiky.riskScore).toBe(27);
+      expect(steady.riskBand).toBe('high');
+      expect(spiky.riskBand).toBe('low');
+      expect(spiky.riskScore!).toBeLessThan(steady.riskScore!);
+    });
+
+    it('scores a user who grew as zero risk', async () => {
+      qb.getRawMany.mockResolvedValue(
+        rowsFor('growing', {
+          1: 5,
+          2: 5,
+          3: 5,
+          4: 5,
+          5: 5,
+          6: 5,
+          7: 5,
+          8: 5,
+          9: 5,
+          10: 20,
+        }),
+      );
+
+      const [point] = (await provider.getChurnRisk(TEN_DAYS)).data;
+
+      expect(point.riskScore).toBe(0);
+      expect(point.riskBand).toBe('none');
+      expect(point.dropRatio).toBe(-3);
+    });
+
+    it('materialises silent buckets as zeros in the baseline', async () => {
+      // Active every other day. If silent buckets were dropped instead of
+      // counted as zeros, the baseline would be [10 x5] -> mean 10, stddev 0,
+      // and this would score 100 instead of 35.
+      qb.getRawMany.mockResolvedValue(
+        rowsFor('intermittent', { 1: 10, 3: 10, 5: 10, 7: 10, 9: 10 }),
+      );
+
+      const [point] = (await provider.getChurnRisk(TEN_DAYS)).data;
+
+      expect(point.baselineBuckets).toBe(9);
+      expect(point.baselineMean).toBe(5.5556);
+      expect(point.riskScore).toBe(35);
+    });
+
+    it('starts the baseline at first activity, not at the range start', async () => {
+      // Signed up on day 6. Counting days 1-5 as zeros would drag the mean down
+      // and make a genuine collapse look mild.
+      qb.getRawMany.mockResolvedValue(
+        rowsFor('newcomer', { 6: 10, 7: 10, 8: 10, 9: 10 }),
+      );
+
+      const [point] = (await provider.getChurnRisk(TEN_DAYS)).data;
+
+      expect(point.baselineBuckets).toBe(4);
+      expect(point.baselineMean).toBe(10);
+      expect(point.recentCount).toBe(0);
+      expect(point.riskScore).toBe(100);
+    });
+  });
+
+  describe('insufficient history', () => {
+    it(`returns null — not 0 — below ${MIN_BASELINE_BUCKETS} baseline buckets`, async () => {
+      qb.getRawMany.mockResolvedValue(rowsFor('fresh', { 8: 10, 9: 10 }));
+
+      const [point] = (await provider.getChurnRisk(TEN_DAYS)).data;
+
+      expect(point.baselineBuckets).toBe(2);
+      expect(point.insufficientBaseline).toBe(true);
+      expect(point.riskScore).toBeNull();
+      expect(point.riskBand).toBeNull();
+      expect(point.dropRatio).toBeNull();
+      // A 0 here would render as "safe" for a user we know nothing about.
+      expect(point.riskScore).not.toBe(0);
+    });
+
+    it('treats a user active only in the recent bucket as unscorable', async () => {
+      qb.getRawMany.mockResolvedValue(rowsFor('brandnew', { 10: 5 }));
+
+      const [point] = (await provider.getChurnRisk(TEN_DAYS)).data;
+
+      expect(point.baselineBuckets).toBe(0);
+      expect(point.insufficientBaseline).toBe(true);
+      expect(point.riskScore).toBeNull();
+    });
+  });
+
+  describe('reporting', () => {
+    it('reports trailing silence without folding it into the score', async () => {
+      // Known limitation, surfaced rather than hidden: this provider measures
+      // the drop, so a user who went quiet early in the window scores modestly
+      // even though they are plainly gone. `consecutiveSilentBuckets` is what
+      // a dormancy metric would key off.
+      qb.getRawMany.mockResolvedValue(
+        rowsFor('longGone', { 1: 10, 2: 10, 3: 10 }),
+      );
+
+      const [point] = (await provider.getChurnRisk(TEN_DAYS)).data;
+
+      expect(point.consecutiveSilentBuckets).toBe(7);
+      expect(point.recentCount).toBe(0);
+      expect(point.riskScore).toBe(22);
+    });
+
+    it('sorts riskiest first and puts unscorable users last', async () => {
+      qb.getRawMany.mockResolvedValue([
+        ...rowsFor('mild', {
+          1: 5,
+          2: 5,
+          3: 5,
+          4: 5,
+          5: 5,
+          6: 5,
+          7: 5,
+          8: 5,
+          9: 5,
+          10: 5,
+        }),
+        ...rowsFor('unscorable', { 9: 3 }),
+        ...rowsFor('severe', {
+          1: 10,
+          2: 10,
+          3: 10,
+          4: 10,
+          5: 10,
+          6: 10,
+          7: 10,
+          8: 11,
+          9: 9,
+          10: 0,
+        }),
+      ]);
+
+      const { data, total } = await provider.getChurnRisk(TEN_DAYS);
+
+      expect(total).toBe(3);
+      expect(data.map((d) => d.userId)).toEqual([
+        'severe',
+        'mild',
+        'unscorable',
+      ]);
+      expect(data[data.length - 1].riskScore).toBeNull();
+    });
+  });
+
+  describe('query shape', () => {
+    it('filters, groups and bounds the scan so it is index-backed', async () => {
+      await provider.getChurnRisk(TEN_DAYS);
+
+      expect(qb.where).toHaveBeenCalledWith(
+        'e."timestamp" >= :start',
+        expect.objectContaining({ start: TEN_DAYS.start }),
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'e."timestamp" <= :end',
+        expect.objectContaining({ end: TEN_DAYS.end }),
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'e."eventType" IN (:...eventTypes)',
+        { eventTypes: ACTIVITY_EVENT_TYPES },
+      );
+      // Aggregation happens in Postgres — one row per (user, bucket) is
+      // returned, rather than every raw event being pulled into the process.
+      expect(qb.groupBy).toHaveBeenCalledWith('e.userId');
+      expect(qb.addSelect).toHaveBeenCalledWith('COUNT(*)::int', 'count');
+    });
+
+    it('excludes one-shot onboarding and system-emitted events', () => {
+      expect(ACTIVITY_EVENT_TYPES).not.toContain('onboarding_completed');
+      expect(ACTIVITY_EVENT_TYPES).not.toContain('first_puzzle_attempted');
+      expect(ACTIVITY_EVENT_TYPES).not.toContain('xp_awarded');
+      expect(ACTIVITY_EVENT_TYPES).toContain('puzzle_attempted');
+    });
+
+    it('truncates to the requested granularity', async () => {
+      await provider.getChurnRisk({
+        start: new Date('2024-01-01T00:00:00.000Z'),
+        end: new Date('2024-06-30T00:00:00.000Z'),
+        granularity: 'week',
+        _dateRange: true,
+      });
+
+      const truncatedTo = (unit: string) =>
+        (qb.addSelect.mock.calls as unknown[][]).some(
+          ([expression]) =>
+            typeof expression === 'string' &&
+            expression.includes(`date_trunc('${unit}'`),
+        );
+
+      expect(truncatedTo('week')).toBe(true);
+      expect(truncatedTo('day')).toBe(false);
+    });
+  });
+});

--- a/backend/src/analytics/providers/get-churn-risk.provider.ts
+++ b/backend/src/analytics/providers/get-churn-risk.provider.ts
@@ -1,0 +1,371 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AnalyticsEvent } from '../entities/analytics-event.entity';
+import { DateRangeDto, RetentionGranularity } from '../dtos/date-range.dto';
+import {
+  AnalyticsMetricResult,
+  ChurnRiskBand,
+  ChurnRiskDataPoint,
+} from '../dtos/analytics-metric-result.dto';
+
+/**
+ * Event types that count as recurring engagement.
+ *
+ * Deliberately excludes the one-shot onboarding events (`onboarding_started`,
+ * `profile_created`, `tutorial_viewed`, `first_puzzle_attempted`,
+ * `onboarding_completed`, `wallet_connected`): they fire once, inflate a new
+ * user's first buckets, and would manufacture a "sharp drop" for every account
+ * the week after signup.
+ *
+ * Also excludes system-emitted consequences (`xp_awarded`, `user_leveled_up`)
+ * which are downstream of the actions above and would double-count them.
+ */
+export const ACTIVITY_EVENT_TYPES = [
+  'puzzle_attempted',
+  'daily_quest_completed',
+  'streak_updated',
+  'login_occurred',
+];
+
+/** Baseline buckets required before a score is emitted at all. */
+export const MIN_BASELINE_BUCKETS = 3;
+
+/** Drop size, in baseline standard deviations, that saturates the score at 100. */
+export const MAX_Z_SCORE = 3;
+
+/** Bounded default window, so a missing `start` never becomes a full-table scan. */
+export const DEFAULT_LOOKBACK_DAYS = 90;
+
+const RISK_BAND_THRESHOLDS: ReadonlyArray<[number, ChurnRiskBand]> = [
+  [67, 'high'],
+  [34, 'medium'],
+  [1, 'low'],
+  [0, 'none'],
+];
+
+/**
+ * `date_trunc` units, keyed by the validated granularity. Values are never
+ * interpolated from raw user input — the DTO restricts granularity to these
+ * three keys and anything else falls back to 'day'.
+ */
+const TRUNC_UNIT: Record<RetentionGranularity, string> = {
+  day: 'day',
+  week: 'week',
+  month: 'month',
+};
+
+interface ChurnRiskRawRow {
+  userId: string;
+  bucket: string;
+  count: string | number;
+}
+
+/**
+ * Flags users whose activity in the most recent bucket has dropped sharply
+ * against their own historical baseline.
+ *
+ * The scoring is variance-relative rather than ratio-relative on purpose. A raw
+ * frequency ratio flags the wrong people: a user who does 40 puzzles a day and
+ * drops to 8 reads as an 80% collapse, while a user who does one a day and
+ * stops entirely reads as a smaller move. Dividing the drop by that user's own
+ * standard deviation means a naturally spiky player needs a much larger drop to
+ * flag than a metronomic one.
+ *
+ * Reads `analytics_events` directly. There is no per-user pre-aggregated table
+ * in this module yet — `retention_cohorts` is cohort-level and carries no
+ * `userId` — so the query is made index-backed instead, against
+ * `IDX_analytics_events_timestamp_userId`. Aggregation happens in Postgres;
+ * only one row per (user, bucket) crosses the wire.
+ */
+@Injectable()
+export class GetChurnRiskProvider {
+  constructor(
+    @InjectRepository(AnalyticsEvent)
+    private readonly analyticsEventRepository: Repository<AnalyticsEvent>,
+  ) {}
+
+  async getChurnRisk(
+    query: DateRangeDto,
+  ): Promise<AnalyticsMetricResult<ChurnRiskDataPoint>> {
+    const granularity: RetentionGranularity = query.granularity ?? 'day';
+    const end = query.end ?? new Date();
+    const start = query.start ?? this.defaultStart(end);
+
+    const startDate = start.toISOString().split('T')[0];
+    const endDate = end.toISOString().split('T')[0];
+    const empty: AnalyticsMetricResult<ChurnRiskDataPoint> = {
+      startDate,
+      endDate,
+      granularity,
+      data: [],
+      total: 0,
+    };
+
+    // An inverted range has no buckets to score. Return empty rather than throw.
+    if (start > end) return empty;
+
+    const buckets = this.enumerateBuckets(start, end, granularity);
+    // A single bucket is all "recent" and leaves nothing to form a baseline.
+    if (buckets.length < MIN_BASELINE_BUCKETS + 1) return empty;
+
+    const rows = await this.fetchBucketCounts(start, end, granularity);
+    if (rows.length === 0) return empty;
+
+    const recentBucket = buckets[buckets.length - 1];
+    const baselineBuckets = buckets.slice(0, -1);
+
+    const byUser = new Map<string, Map<string, number>>();
+    for (const row of rows) {
+      const counts = byUser.get(row.userId) ?? new Map<string, number>();
+      counts.set(row.bucket, Number(row.count) || 0);
+      byUser.set(row.userId, counts);
+    }
+
+    const data: ChurnRiskDataPoint[] = [];
+    for (const [userId, counts] of byUser) {
+      data.push(this.scoreUser(userId, counts, baselineBuckets, recentBucket));
+    }
+
+    this.sortByRisk(data);
+
+    return { startDate, endDate, granularity, data, total: data.length };
+  }
+
+  private defaultStart(end: Date): Date {
+    const start = new Date(end);
+    start.setUTCDate(start.getUTCDate() - DEFAULT_LOOKBACK_DAYS);
+    return start;
+  }
+
+  private async fetchBucketCounts(
+    start: Date,
+    end: Date,
+    granularity: RetentionGranularity,
+  ): Promise<ChurnRiskRawRow[]> {
+    const unit = TRUNC_UNIT[granularity] ?? TRUNC_UNIT.day;
+    // Pinned to UTC so the bucket boundaries do not move with the DB session
+    // timezone, and so `truncateToBucket` below can mirror them exactly.
+    const bucketExpr = `date_trunc('${unit}', e."timestamp" AT TIME ZONE 'UTC')`;
+
+    return this.analyticsEventRepository
+      .createQueryBuilder('e')
+      .select('e.userId', 'userId')
+      .addSelect(`to_char(${bucketExpr}, 'YYYY-MM-DD"T"HH24:MI:SS')`, 'bucket')
+      .addSelect('COUNT(*)::int', 'count')
+      .where('e."timestamp" >= :start', { start })
+      .andWhere('e."timestamp" <= :end', { end })
+      .andWhere('e."eventType" IN (:...eventTypes)', {
+        eventTypes: ACTIVITY_EVENT_TYPES,
+      })
+      .groupBy('e.userId')
+      .addGroupBy(bucketExpr)
+      .getRawMany<ChurnRiskRawRow>();
+  }
+
+  private scoreUser(
+    userId: string,
+    counts: Map<string, number>,
+    baselineBuckets: string[],
+    recentBucket: string,
+  ): ChurnRiskDataPoint {
+    const recentCount = counts.get(recentBucket) ?? 0;
+
+    // A user's baseline starts at their first observed activity, not at the
+    // start of the range — otherwise every account looks dormant for every
+    // bucket that predates its signup. From that point on, silent buckets are
+    // materialised as zeros; dropping them would only average the active days
+    // and hide the exact decline this provider exists to find.
+    const firstActive = baselineBuckets.findIndex(
+      (b) => (counts.get(b) ?? 0) > 0,
+    );
+    const values =
+      firstActive === -1
+        ? []
+        : baselineBuckets.slice(firstActive).map((b) => counts.get(b) ?? 0);
+
+    const consecutiveSilentBuckets = this.trailingZeros([
+      ...values,
+      recentCount,
+    ]);
+
+    if (values.length < MIN_BASELINE_BUCKETS) {
+      return this.insufficient(
+        userId,
+        recentCount,
+        values.length,
+        consecutiveSilentBuckets,
+      );
+    }
+
+    const baselineMean = values.reduce((a, b) => a + b, 0) / values.length;
+    if (baselineMean === 0) {
+      return this.insufficient(
+        userId,
+        recentCount,
+        values.length,
+        consecutiveSilentBuckets,
+      );
+    }
+
+    const baselineStdDev = this.sampleStdDev(values, baselineMean);
+    const dropRatio = (baselineMean - recentCount) / baselineMean;
+    const riskScore = this.riskScore(
+      baselineMean,
+      baselineStdDev,
+      recentCount,
+      dropRatio,
+    );
+
+    return {
+      userId,
+      riskScore,
+      riskBand: this.bandFor(riskScore),
+      baselineMean: this.round(baselineMean, 4),
+      baselineStdDev: this.round(baselineStdDev, 4),
+      baselineBuckets: values.length,
+      recentCount,
+      consecutiveSilentBuckets,
+      dropRatio: this.round(dropRatio, 4),
+      insufficientBaseline: false,
+    };
+  }
+
+  /** Trailing run of zero-activity buckets, most recent bucket included. */
+  private trailingZeros(values: number[]): number {
+    let run = 0;
+    for (let i = values.length - 1; i >= 0 && values[i] === 0; i--) run++;
+    return run;
+  }
+
+  private riskScore(
+    mean: number,
+    stdDev: number,
+    recentCount: number,
+    dropRatio: number,
+  ): number {
+    // Held steady or grew — not a churn signal regardless of variance.
+    if (recentCount >= mean) return 0;
+
+    // Perfectly regular history: there is no variance to normalise against, so
+    // fall back to the size of the drop itself.
+    if (stdDev === 0) return Math.round(dropRatio * 100);
+
+    const z = (mean - recentCount) / stdDev;
+    return Math.round(Math.min(1, z / MAX_Z_SCORE) * 100);
+  }
+
+  private insufficient(
+    userId: string,
+    recentCount: number,
+    baselineBuckets: number,
+    consecutiveSilentBuckets: number,
+  ): ChurnRiskDataPoint {
+    // Null, never 0. A 0 here would render as "no churn risk" on the dashboard
+    // for a user we simply know nothing about yet.
+    return {
+      userId,
+      riskScore: null,
+      riskBand: null,
+      baselineMean: 0,
+      baselineStdDev: 0,
+      baselineBuckets,
+      recentCount,
+      consecutiveSilentBuckets,
+      dropRatio: null,
+      insufficientBaseline: true,
+    };
+  }
+
+  private sampleStdDev(values: number[], mean: number): number {
+    if (values.length < 2) return 0;
+    const variance =
+      values.reduce((acc, v) => acc + (v - mean) ** 2, 0) / (values.length - 1);
+    return Math.sqrt(variance);
+  }
+
+  private bandFor(riskScore: number | null): ChurnRiskBand | null {
+    if (riskScore === null) return null;
+    for (const [threshold, band] of RISK_BAND_THRESHOLDS) {
+      if (riskScore >= threshold) return band;
+    }
+    return 'none';
+  }
+
+  /** Riskiest first; unscorable users last; userId as a stable tiebreak. */
+  private sortByRisk(data: ChurnRiskDataPoint[]): void {
+    data.sort((a, b) => {
+      if (a.riskScore === null && b.riskScore === null) {
+        return a.userId.localeCompare(b.userId);
+      }
+      if (a.riskScore === null) return 1;
+      if (b.riskScore === null) return -1;
+      if (b.riskScore !== a.riskScore) return b.riskScore - a.riskScore;
+      return a.userId.localeCompare(b.userId);
+    });
+  }
+
+  /**
+   * Mirrors `date_trunc(unit, ts AT TIME ZONE 'UTC')`. Postgres truncates weeks
+   * to Monday, so this does too.
+   */
+  private truncateToBucket(
+    date: Date,
+    granularity: RetentionGranularity,
+  ): Date {
+    if (granularity === 'month') {
+      return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+    }
+
+    const truncated = new Date(
+      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+    );
+
+    if (granularity === 'week') {
+      const daysSinceMonday = (truncated.getUTCDay() + 6) % 7;
+      truncated.setUTCDate(truncated.getUTCDate() - daysSinceMonday);
+    }
+
+    return truncated;
+  }
+
+  private advanceBucket(date: Date, granularity: RetentionGranularity): Date {
+    const next = new Date(date);
+    if (granularity === 'month') next.setUTCMonth(next.getUTCMonth() + 1);
+    else if (granularity === 'week') next.setUTCDate(next.getUTCDate() + 7);
+    else next.setUTCDate(next.getUTCDate() + 1);
+    return next;
+  }
+
+  /**
+   * The full bucket grid for the range. Built from the range rather than from
+   * the returned rows, so that buckets in which nobody was active still exist
+   * and still count as zeros against every user's baseline.
+   */
+  private enumerateBuckets(
+    start: Date,
+    end: Date,
+    granularity: RetentionGranularity,
+  ): string[] {
+    const keys: string[] = [];
+    const last = this.truncateToBucket(end, granularity);
+    let cursor = this.truncateToBucket(start, granularity);
+
+    while (cursor <= last) {
+      keys.push(this.bucketKey(cursor));
+      cursor = this.advanceBucket(cursor, granularity);
+    }
+
+    return keys;
+  }
+
+  /** `YYYY-MM-DDTHH:mm:ss` — matches the `to_char` format used in the query. */
+  private bucketKey(date: Date): string {
+    return date.toISOString().slice(0, 19);
+  }
+
+  private round(value: number, places: number): number {
+    const factor = 10 ** places;
+    return Math.round(value * factor) / factor;
+  }
+}

--- a/backend/src/database/migrations/20260722000000-AddAnalyticsEventIndexes.ts
+++ b/backend/src/database/migrations/20260722000000-AddAnalyticsEventIndexes.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * `analytics_events` shipped without any index, so every reporting query over it
+ * is a sequential scan. These two cover the access patterns the analytics
+ * providers actually use:
+ *
+ *  - IDX_analytics_events_timestamp_userId — range scan over a reporting window
+ *    grouped by user (churn risk scoring, future per-user rollups).
+ *  - IDX_analytics_events_userId_timestamp — one user's history in time order.
+ *
+ * Note: these are plain (non-CONCURRENT) index builds because TypeORM runs
+ * migrations inside a transaction and CREATE INDEX CONCURRENTLY cannot run
+ * there. On a large existing table this takes a write lock for the duration.
+ */
+export class AddAnalyticsEventIndexes20260722000000 implements MigrationInterface {
+  name = 'AddAnalyticsEventIndexes20260722000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1 FROM information_schema.tables
+          WHERE table_name = 'analytics_events'
+        ) THEN
+          CREATE INDEX IF NOT EXISTS "IDX_analytics_events_timestamp_userId"
+            ON "analytics_events" ("timestamp", "userId");
+
+          CREATE INDEX IF NOT EXISTS "IDX_analytics_events_userId_timestamp"
+            ON "analytics_events" ("userId", "timestamp");
+        END IF;
+      END $$;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "IDX_analytics_events_userId_timestamp";
+      DROP INDEX IF EXISTS "IDX_analytics_events_timestamp_userId";
+    `);
+  }
+}


### PR DESCRIPTION
Closes #521

Adds `GetChurnRiskProvider`, which flags users whose activity in the most recent
bucket has dropped sharply against their own historical baseline. Accepts
`DateRangeDto` with optional granularity and returns a typed
`AnalyticsMetricResult`.

## On the data source

Following up on my comment in the issue, since this shaped the implementation.

Churn risk is a per-user metric, but `retention_cohorts` is cohort-level and
carries no `userId`, so it can't produce per-user flags. The fallback is raw
`analytics_events`, which had no indexes at all — while every other module
indexes this shape (`progress.entity.ts` has `['userId','attemptedAt']`).

So "query pre-aggregated tables where one exists" and "index-backed, no full
table scan" couldn't both be satisfied as the repo stood. I took the cheaper of
the two paths: index `analytics_events` and aggregate in Postgres, rather than
introduce a per-user rollup entity plus an aggregation job, which is a much
larger change than the two files the issue lists.

**If you'd rather have the rollup, the scoring logic transfers unchanged** —
only `fetchBucketCounts` gets swapped. Happy to do that in a follow-up, or redo
this PR that way if you prefer it up front.

The query aggregates via `date_trunc` + `GROUP BY`, so only one row per
(user, bucket) crosses the wire rather than every raw event.

## On the scoring

The hard part isn't the drop calculation, it's that a naive frequency ratio
flags the wrong people. A user doing 40 puzzles a day who drops to 8 reads as an
80% collapse; a user doing one a day who stops entirely reads as a smaller move.

So the drop is divided by that user's own standard deviation. A naturally spiky
player needs a much larger drop to flag than a metronomic one. There's a test
covering exactly this: two users land on an identical recent count, and the
steady one scores 100 while the spiky one scores 27.

## Decisions worth pushing back on

- **`ACTIVITY_EVENT_TYPES` excludes one-shot onboarding events.** Including them
  would inflate a new user's first buckets and manufacture a "sharp drop" for
  every account the week after signup. It also excludes `xp_awarded` and
  `user_leveled_up`, which are consequences of the actions already counted. This
  is an opinion about the taxonomy — easy to disagree with.
- **Baseline starts at a user's first observed activity**, not the range start,
  so accounts aren't penalised for buckets that predate signup. From there,
  silent buckets are materialised as zeros; dropping them would average only the
  active days and hide the decline. Both behaviours have tests.
- **Insufficient history returns `null`, not `0`**, matching how `cohortSize === 0`
  already returns null instead of dividing. A 0 would render as "no risk" for a
  user we know nothing about.
- **Buckets are pinned to UTC** so boundaries don't move with the DB session
  timezone, and the JS grid mirrors `date_trunc` exactly, including Monday-start
  weeks. This is the most fragile part of the change and the bit I'd most want a
  second pair of eyes on.
- **A missing `start` defaults to a bounded 90-day lookback** rather than epoch.
  The existing providers default to `new Date(0)`, which against an unindexed
  table is a scan of everything.

## Known limitation

A user who went quiet early in the window scores modestly (22, "low") even
though they're plainly gone — this measures the *drop*, and by then the
transition already happened outside the comparison. I nearly folded a dormancy
term into the score and deliberately didn't: it would have over-flagged exactly
the spiky users the variance normalisation exists to protect.

Instead `consecutiveSilentBuckets` is reported unscored, and there's a test
asserting the 22 with a comment explaining why. **Sustained dormancy probably
wants its own metric** — worth your call.

## Other changes

- `AnalyticsMetricResult.data` was hardcoded to `RetentionDataPoint[]`, so it's
  now `AnalyticsMetricResult<T = RetentionDataPoint>`. The default keeps the
  retention provider, its spec, and the `users/retention` route compiling
  unchanged.
- Adds `GET /analytics/users/churn-risk` behind `AnalyticsAdminGuard`, matching
  the route added in #527. Because the result type is now generic, the response
  schema is declared with `ApiExtraModels` + `getSchemaPath` rather than
  `@ApiResponse({ type: ... })` — the latter would advertise `RetentionDataPoint`
  as the element type. Happy to align both routes on one style if you prefer.
- Drops an unused `ApiQuery` import while restructuring that import block.

Rebased onto `main` after #588, #586 and #583. The only conflict was
`analytics.module.ts`, where #588 added `AnalyticsService` to the same arrays.


## Verification

- `tsc --noEmit` — clean
- `jest src/analytics` — 30/30 passing, 4 suites (17 new, 13 existing). Both
  existing analytics specs still pass, so the generic change didn't break
  retention.
- `eslint` on the changed files — clean

## Heads-up on lint

`npm run lint` is `eslint "{src,apps,libs,test}/**/*.ts" --fix` — `--fix` is
baked into the script. On Windows with `core.autocrlf=true` it rewrites line
endings across the entire backend and produces a ~170-file diff. It's a footgun
for any Windows contributor, given CONTRIBUTING tells everyone to run it before
a PR. Might be worth splitting into `lint` and `lint:fix`.

Separately, lint exits 1 on `main` already — 112 pre-existing errors in
`health.*`, `main.ts` and others, none in this PR's files. So a red lint check
here isn't from these changes.
