### PR TITLE
feat(analytics): add GET /analytics/export endpoint (#536)

### DIFF
--- a/backend/src/analytics/analytics.module.ts
+++ b/backend/src/analytics/analytics.module.ts
@@ -9,6 +9,7 @@ import { TrackEventProvider } from './providers/track-event.provider';
 import { GetOnboardingFunnelProvider } from './providers/get-onboarding-funnel.provider';
 import { GetRetentionCurveProvider } from './providers/get-retention-curve.provider';
 import { GetChurnRiskProvider } from './providers/get-churn-risk.provider';
+import { ExportCsvProvider } from './providers/export-csv.provider';
 
 @Module({
   imports: [TypeOrmModule.forFeature([AnalyticsEvent, RetentionCohort])],
@@ -20,6 +21,7 @@ import { GetChurnRiskProvider } from './providers/get-churn-risk.provider';
     GetOnboardingFunnelProvider,
     GetRetentionCurveProvider,
     GetChurnRiskProvider,
+    ExportCsvProvider,
   ],
   exports: [
     AnalyticsService,
@@ -27,6 +29,7 @@ import { GetChurnRiskProvider } from './providers/get-churn-risk.provider';
     GetOnboardingFunnelProvider,
     GetRetentionCurveProvider,
     GetChurnRiskProvider,
+    ExportCsvProvider,
     TypeOrmModule,
   ],
 })

--- a/backend/src/analytics/controllers/analytics.controller.ts
+++ b/backend/src/analytics/controllers/analytics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Get, Query, UseGuards } from '@nestjs/common';
+import { Controller, Post, Body, Get, Query, Res, UseGuards } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -6,13 +6,16 @@ import {
   ApiExtraModels,
   getSchemaPath,
 } from '@nestjs/swagger';
+import type { Response } from 'express';
 import { TrackEventProvider } from '../providers/track-event.provider';
 import { GetOnboardingFunnelProvider } from '../providers/get-onboarding-funnel.provider';
 import { GetRetentionCurveProvider } from '../providers/get-retention-curve.provider';
 import { GetChurnRiskProvider } from '../providers/get-churn-risk.provider';
+import { ExportCsvProvider } from '../providers/export-csv.provider';
 import { AnalyticsService } from '../analytics.service';
 import { TrackEventDto } from '../dtos/track-event.dto';
 import { DateRangeDto } from '../dtos/date-range.dto';
+import { AnalyticsQueryDto } from '../dtos/analytics-query.dto';
 import {
   AnalyticsMetricResult,
   ChurnRiskDataPoint,
@@ -27,6 +30,7 @@ export class AnalyticsController {
     private readonly getOnboardingFunnelProvider: GetOnboardingFunnelProvider,
     private readonly getRetentionCurveProvider: GetRetentionCurveProvider,
     private readonly getChurnRiskProvider: GetChurnRiskProvider,
+    private readonly exportCsvProvider: ExportCsvProvider,
     private readonly analyticsService: AnalyticsService,
   ) {}
 
@@ -82,5 +86,27 @@ export class AnalyticsController {
   })
   async getChurnRisk(@Query() query: DateRangeDto) {
     return this.getChurnRiskProvider.getChurnRisk(query);
+  }
+
+  @Get('export')
+  @UseGuards(AnalyticsAdminGuard)
+  @ApiOperation({
+    summary: 'Export a chosen analytics metric over a date range (admin only)',
+  })
+  @ApiResponse({ status: 200, description: 'CSV or JSON export of the requested metric' })
+  async exportMetric(
+    @Query() query: AnalyticsQueryDto,
+    @Res() res: Response,
+  ) {
+    const result = await this.exportCsvProvider.export(query);
+
+    res.setHeader('Content-Type', result.contentType);
+    if (result.contentType === 'text/csv') {
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${result.filename}"`,
+      );
+    }
+    res.status(200).send(result.body);
   }
 }

--- a/backend/src/analytics/dtos/analytics-query.dto.ts
+++ b/backend/src/analytics/dtos/analytics-query.dto.ts
@@ -1,0 +1,33 @@
+import { IsEnum, IsOptional } from 'class-validator';
+import { ApiPropertyOptional, ApiProperty } from '@nestjs/swagger';
+import { DateRangeDto } from './date-range.dto';
+
+export enum ExportMetric {
+  RETENTION = 'retention',
+  ONBOARDING_FUNNEL = 'onboarding_funnel',
+}
+
+export enum ExportFormat {
+  CSV = 'csv',
+  JSON = 'json',
+}
+
+export class AnalyticsQueryDto extends DateRangeDto {
+  @ApiProperty({
+    enum: ExportMetric,
+    example: ExportMetric.RETENTION,
+    description: 'Which analytics metric to export',
+  })
+  @IsEnum(ExportMetric)
+  metric: ExportMetric;
+
+  @ApiPropertyOptional({
+    enum: ExportFormat,
+    example: ExportFormat.CSV,
+    default: ExportFormat.CSV,
+    description: 'Output format for the export',
+  })
+  @IsOptional()
+  @IsEnum(ExportFormat)
+  format?: ExportFormat = ExportFormat.CSV;
+}

--- a/backend/src/analytics/providers/export-csv.provider.ts
+++ b/backend/src/analytics/providers/export-csv.provider.ts
@@ -1,0 +1,138 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Between, Repository } from 'typeorm';
+import { format as formatCsv } from 'fast-csv';
+import { AnalyticsEvent } from '../entities/analytics-event.entity';
+import { RetentionCohort } from '../entities/retention-cohort.entity';
+import {
+  AnalyticsQueryDto,
+  ExportMetric,
+  ExportFormat,
+} from '../dtos/analytics-query.dto';
+
+const ONBOARDING_EVENTS = [
+  { name: 'Onboarding Started', eventType: 'onboarding_started' },
+  { name: 'Profile Created', eventType: 'profile_created' },
+  { name: 'Tutorial Viewed', eventType: 'tutorial_viewed' },
+  { name: 'First Puzzle Attempted', eventType: 'first_puzzle_attempted' },
+  { name: 'Onboarding Completed', eventType: 'onboarding_completed' },
+];
+
+export interface ExportResult {
+  contentType: string;
+  filename: string;
+  body: string;
+}
+
+/**
+ * Exports a chosen analytics metric (retention curve or onboarding funnel)
+ * over a date range, as CSV or JSON.
+ *
+ * Queries the same underlying tables as GetRetentionCurveProvider /
+ * GetOnboardingFunnelProvider directly, rather than depending on those
+ * providers, so this stays a self-contained unit with two mockable
+ * repositories.
+ */
+@Injectable()
+export class ExportCsvProvider {
+  constructor(
+    @InjectRepository(RetentionCohort)
+    private readonly retentionCohortRepo: Repository<RetentionCohort>,
+    @InjectRepository(AnalyticsEvent)
+    private readonly analyticsEventRepo: Repository<AnalyticsEvent>,
+  ) {}
+
+  async export(query: AnalyticsQueryDto): Promise<ExportResult> {
+    const { metric, format = ExportFormat.CSV } = query;
+
+    const rows =
+      metric === ExportMetric.RETENTION
+        ? await this.getRetentionRows(query)
+        : await this.getFunnelRows(query);
+
+    const filename = `analytics-export-${metric}.${format}`;
+
+    if (format === ExportFormat.JSON) {
+      return {
+        contentType: 'application/json',
+        filename,
+        body: JSON.stringify(rows),
+      };
+    }
+
+    const body = await this.toCsv(rows, metric);
+    return { contentType: 'text/csv', filename, body };
+  }
+
+  private async getRetentionRows(
+    query: AnalyticsQueryDto,
+  ): Promise<Record<string, unknown>[]> {
+    const startDate = query.start
+      ? query.start.toISOString().split('T')[0]
+      : new Date(0).toISOString().split('T')[0];
+    const endDate = query.end
+      ? query.end.toISOString().split('T')[0]
+      : new Date().toISOString().split('T')[0];
+
+    const cohorts = await this.retentionCohortRepo.find({
+      where: { cohortDate: Between(startDate, endDate) as any },
+      order: { cohortDate: 'ASC' },
+    });
+
+    return cohorts.map((c) => ({
+      cohortDate: c.cohortDate,
+      cohortSize: c.cohortSize,
+      retainedDay1: c.retainedDay1,
+      retainedDay7: c.retainedDay7,
+      retainedDay30: c.retainedDay30,
+    }));
+  }
+
+  private async getFunnelRows(
+    query: AnalyticsQueryDto,
+  ): Promise<Record<string, unknown>[]> {
+    const start = query.start || new Date(0);
+    const end = query.end || new Date();
+
+    const rows: Record<string, unknown>[] = [];
+    for (const stage of ONBOARDING_EVENTS) {
+      const count = await this.analyticsEventRepo.count({
+        where: { eventType: stage.eventType, timestamp: Between(start, end) },
+      });
+      rows.push({ stage: stage.name, eventType: stage.eventType, count });
+    }
+    return rows;
+  }
+
+  private static readonly CSV_HEADERS: Record<ExportMetric, string[]> = {
+    [ExportMetric.RETENTION]: [
+      'cohortDate',
+      'cohortSize',
+      'retainedDay1',
+      'retainedDay7',
+      'retainedDay30',
+    ],
+    [ExportMetric.ONBOARDING_FUNNEL]: ['stage', 'eventType', 'count'],
+  };
+
+  private toCsv(
+    rows: Record<string, unknown>[],
+    metric: ExportMetric,
+  ): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const chunks: string[] = [];
+      const headers = ExportCsvProvider.CSV_HEADERS[metric];
+      // alwaysWriteHeaders ensures a header-only CSV for empty results,
+      // instead of an ambiguous empty body.
+      const stream = formatCsv({ headers, alwaysWriteHeaders: true });
+      stream.on('data', (chunk) => chunks.push(chunk.toString()));
+      stream.on('end', () => resolve(chunks.join('')));
+      stream.on('error', reject);
+
+      for (const row of rows) {
+        stream.write(row);
+      }
+      stream.end();
+    });
+  }
+}

--- a/backend/test/analytics.e2e-spec.ts
+++ b/backend/test/analytics.e2e-spec.ts
@@ -10,6 +10,9 @@ import { AnalyticsController } from '../src/analytics/controllers/analytics.cont
 import { TrackEventProvider } from '../src/analytics/providers/track-event.provider';
 import { GetOnboardingFunnelProvider } from '../src/analytics/providers/get-onboarding-funnel.provider';
 import { GetRetentionCurveProvider } from '../src/analytics/providers/get-retention-curve.provider';
+import { GetChurnRiskProvider } from '../src/analytics/providers/get-churn-risk.provider';
+import { ExportCsvProvider } from '../src/analytics/providers/export-csv.provider';
+import { AnalyticsService } from '../src/analytics/analytics.service';
 import { AnalyticsAdminGuard } from '../src/analytics/guards/analytics-admin.guard';
 import { AnalyticsMetricResult } from '../src/analytics/dtos/analytics-metric-result.dto';
 
@@ -17,6 +20,7 @@ describe('GET /analytics/users/retention (e2e)', () => {
   let app: INestApplication<App>;
 
   const mockGetRetentionCurveProvider = { getRetentionCurve: jest.fn() };
+  const mockExportCsvProvider = { export: jest.fn() };
 
   const fakeResult: AnalyticsMetricResult = {
     startDate: '2024-01-01',
@@ -49,6 +53,9 @@ describe('GET /analytics/users/retention (e2e)', () => {
           provide: GetRetentionCurveProvider,
           useValue: mockGetRetentionCurveProvider,
         },
+        { provide: GetChurnRiskProvider, useValue: {} },
+        { provide: ExportCsvProvider, useValue: mockExportCsvProvider },
+        { provide: AnalyticsService, useValue: {} },
       ],
     })
       .overrideGuard(AnalyticsAdminGuard)
@@ -155,5 +162,130 @@ describe('GET /analytics/users/retention (e2e)', () => {
       .expect(400);
 
     expect(mockGetRetentionCurveProvider.getRetentionCurve).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /analytics/export (e2e)', () => {
+  let app: INestApplication<App>;
+
+  const mockExportCsvProvider = { export: jest.fn() };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [AnalyticsController],
+      providers: [
+        { provide: TrackEventProvider, useValue: {} },
+        { provide: GetOnboardingFunnelProvider, useValue: {} },
+        { provide: GetRetentionCurveProvider, useValue: {} },
+        { provide: GetChurnRiskProvider, useValue: {} },
+        { provide: ExportCsvProvider, useValue: mockExportCsvProvider },
+        { provide: AnalyticsService, useValue: {} },
+      ],
+    })
+      .overrideGuard(AnalyticsAdminGuard)
+      .useValue({
+        canActivate: (context: ExecutionContext) => {
+          const req = context.switchToHttp().getRequest();
+          return req.headers['x-test-role'] === 'admin';
+        },
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 200 with a CSV attachment for a retention export', async () => {
+    mockExportCsvProvider.export.mockResolvedValue({
+      contentType: 'text/csv',
+      filename: 'analytics-export-retention.csv',
+      body: 'cohortDate,cohortSize,retainedDay1,retainedDay7,retainedDay30\n2024-01-15,100,70,50,30\n',
+    });
+
+    const res = await request(app.getHttpServer())
+      .get('/analytics/export')
+      .set('x-test-role', 'admin')
+      .query({
+        metric: 'retention',
+        start: '2024-01-01T00:00:00.000Z',
+        end: '2024-01-31T00:00:00.000Z',
+      })
+      .expect(200);
+
+    expect(res.headers['content-type']).toContain('text/csv');
+    expect(res.headers['content-disposition']).toContain(
+      'attachment; filename="analytics-export-retention.csv"',
+    );
+    expect(res.text).toContain('cohortDate,cohortSize');
+    expect(mockExportCsvProvider.export).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 200 with a JSON body for an onboarding_funnel export', async () => {
+    const fakeRows = [{ stage: 'Onboarding Started', eventType: 'onboarding_started', count: 42 }];
+    mockExportCsvProvider.export.mockResolvedValue({
+      contentType: 'application/json',
+      filename: 'analytics-export-onboarding_funnel.json',
+      body: JSON.stringify(fakeRows),
+    });
+
+    const res = await request(app.getHttpServer())
+      .get('/analytics/export')
+      .set('x-test-role', 'admin')
+      .query({ metric: 'onboarding_funnel', format: 'json' })
+      .expect(200);
+
+    expect(res.headers['content-type']).toContain('application/json');
+    expect(res.body).toEqual(fakeRows);
+    expect(mockExportCsvProvider.export).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 403 for a caller without the admin role', async () => {
+    await request(app.getHttpServer())
+      .get('/analytics/export')
+      .query({ metric: 'retention' })
+      .expect(403);
+
+    expect(mockExportCsvProvider.export).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 with a clear validation message when metric is missing', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/analytics/export')
+      .set('x-test-role', 'admin')
+      .query({})
+      .expect(400);
+
+    expect(res.body.message).toEqual(
+      expect.arrayContaining([expect.stringContaining('metric')]),
+    );
+    expect(mockExportCsvProvider.export).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 with a clear validation message for an invalid metric', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/analytics/export')
+      .set('x-test-role', 'admin')
+      .query({ metric: 'not_a_real_metric' })
+      .expect(400);
+
+    expect(res.body.message).toEqual(
+      expect.arrayContaining([expect.stringContaining('metric')]),
+    );
+    expect(mockExportCsvProvider.export).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- Add AnalyticsQueryDto with metric (retention | onboarding_funnel) and format (csv | json) params
- Add ExportCsvProvider, querying RetentionCohort/AnalyticsEvent repos directly and serializing to CSV (fast-csv) or JSON
- Wire GET /analytics/export on AnalyticsController, guarded by AnalyticsAdminGuard
- Register ExportCsvProvider in AnalyticsModule
- Add e2e coverage for the export route, and fix a pre-existing DI gap in analytics.e2e-spec.ts (GetChurnRiskProvider/AnalyticsService were never mocked after the churn-risk PR, breaking the whole retention test suite)

closes #536