### PR TITLE
feat(analytics): add GET /analytics/puzzles/:id/stats route, PuzzleAn…

### DIFF
--- a/backend/src/analytics/analytics.module.ts
+++ b/backend/src/analytics/analytics.module.ts
@@ -10,6 +10,7 @@ import { TrackEventProvider } from './providers/track-event.provider';
 import { GetOnboardingFunnelProvider } from './providers/get-onboarding-funnel.provider';
 import { GetRetentionCurveProvider } from './providers/get-retention-curve.provider';
 import { GetChurnRiskProvider } from './providers/get-churn-risk.provider';
+import { PuzzleAnalyticsProvider } from './providers/puzzle-analytics.provider';
 import { ExportCsvProvider } from './providers/export-csv.provider';
 
 @Module({
@@ -28,6 +29,7 @@ import { ExportCsvProvider } from './providers/export-csv.provider';
     GetOnboardingFunnelProvider,
     GetRetentionCurveProvider,
     GetChurnRiskProvider,
+    PuzzleAnalyticsProvider,
     ExportCsvProvider,
   ],
   exports: [
@@ -36,6 +38,7 @@ import { ExportCsvProvider } from './providers/export-csv.provider';
     GetOnboardingFunnelProvider,
     GetRetentionCurveProvider,
     GetChurnRiskProvider,
+    PuzzleAnalyticsProvider,
     ExportCsvProvider,
     TypeOrmModule,
   ],

--- a/backend/src/analytics/controllers/analytics.controller.ts
+++ b/backend/src/analytics/controllers/analytics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Get, Query, Res, UseGuards } from '@nestjs/common';
+import { Controller, Post, Body, Get, Query, Param, Res, UseGuards } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -11,6 +11,7 @@ import { TrackEventProvider } from '../providers/track-event.provider';
 import { GetOnboardingFunnelProvider } from '../providers/get-onboarding-funnel.provider';
 import { GetRetentionCurveProvider } from '../providers/get-retention-curve.provider';
 import { GetChurnRiskProvider } from '../providers/get-churn-risk.provider';
+import { PuzzleAnalyticsProvider } from '../providers/puzzle-analytics.provider';
 import { ExportCsvProvider } from '../providers/export-csv.provider';
 import { AnalyticsService } from '../analytics.service';
 import { TrackEventDto } from '../dtos/track-event.dto';
@@ -19,6 +20,7 @@ import { AnalyticsQueryDto } from '../dtos/analytics-query.dto';
 import {
   AnalyticsMetricResult,
   ChurnRiskDataPoint,
+  PuzzleStatsResult,
 } from '../dtos/analytics-metric-result.dto';
 import { AnalyticsAdminGuard } from '../guards/analytics-admin.guard';
 
@@ -30,6 +32,7 @@ export class AnalyticsController {
     private readonly getOnboardingFunnelProvider: GetOnboardingFunnelProvider,
     private readonly getRetentionCurveProvider: GetRetentionCurveProvider,
     private readonly getChurnRiskProvider: GetChurnRiskProvider,
+    private readonly puzzleAnalyticsProvider: PuzzleAnalyticsProvider,
     private readonly exportCsvProvider: ExportCsvProvider,
     private readonly analyticsService: AnalyticsService,
   ) {}
@@ -86,6 +89,17 @@ export class AnalyticsController {
   })
   async getChurnRisk(@Query() query: DateRangeDto) {
     return this.getChurnRiskProvider.getChurnRisk(query);
+  }
+
+  @Get('puzzles/:id/stats')
+  @UseGuards(AnalyticsAdminGuard)
+  @ApiOperation({ summary: 'Get detailed stats for a single puzzle (admin only)' })
+  @ApiResponse({ status: 200, type: PuzzleStatsResult })
+  async getPuzzleStats(
+    @Param('id') puzzleId: string,
+    @Query() query: DateRangeDto,
+  ) {
+    return this.puzzleAnalyticsProvider.getPuzzleStats(puzzleId, query);
   }
 
   @Get('export')

--- a/backend/src/analytics/dtos/analytics-metric-result.dto.ts
+++ b/backend/src/analytics/dtos/analytics-metric-result.dto.ts
@@ -101,3 +101,33 @@ export class AnalyticsMetricResult<T = RetentionDataPoint> {
   @ApiProperty({ example: 15, description: 'Total rows returned' })
   total: number;
 }
+
+export class PuzzleStatsResult {
+  @ApiProperty({ example: 'puzzle-uuid-123', description: 'Puzzle unique ID' })
+  puzzleId: string;
+
+  @ApiProperty({ example: 150, description: 'Total attempts made on this puzzle' })
+  totalAttempts: number;
+
+  @ApiProperty({ example: 105, description: 'Total correct/successful attempts' })
+  successfulAttempts: number;
+
+  @ApiProperty({ example: 45, description: 'Total incorrect/failed attempts' })
+  failedAttempts: number;
+
+  @ApiProperty({ example: 70, description: 'Success rate percentage (0-100)' })
+  successRate: number;
+
+  @ApiProperty({ example: 35.5, description: 'Average time spent in seconds' })
+  averageTimeSpent: number;
+
+  @ApiProperty({ example: 42, description: 'Unique users who attempted this puzzle' })
+  uniqueUsers: number;
+
+  @ApiProperty({ example: '2024-01-01', description: 'Start date of stats window', required: false })
+  startDate?: string;
+
+  @ApiProperty({ example: '2024-01-31', description: 'End date of stats window', required: false })
+  endDate?: string;
+}
+

--- a/backend/src/analytics/dtos/analytics-query.dto.ts
+++ b/backend/src/analytics/dtos/analytics-query.dto.ts
@@ -5,6 +5,7 @@ import { DateRangeDto } from './date-range.dto';
 export enum ExportMetric {
   RETENTION = 'retention',
   ONBOARDING_FUNNEL = 'onboarding_funnel',
+  PUZZLE_STATS = 'puzzle_stats',
 }
 
 export enum ExportFormat {

--- a/backend/src/analytics/providers/export-csv.provider.ts
+++ b/backend/src/analytics/providers/export-csv.provider.ts
@@ -113,6 +113,15 @@ export class ExportCsvProvider {
       'retainedDay30',
     ],
     [ExportMetric.ONBOARDING_FUNNEL]: ['stage', 'eventType', 'count'],
+    [ExportMetric.PUZZLE_STATS]: [
+      'puzzleId',
+      'totalAttempts',
+      'successfulAttempts',
+      'failedAttempts',
+      'successRate',
+      'averageTimeSpent',
+      'uniqueUsers',
+    ],
   };
 
   private toCsv(

--- a/backend/src/analytics/providers/puzzle-analytics.entity.ts
+++ b/backend/src/analytics/providers/puzzle-analytics.entity.ts
@@ -1,0 +1,1 @@
+export * from './puzzle-analytics.provider';

--- a/backend/src/analytics/providers/puzzle-analytics.provider.spec.ts
+++ b/backend/src/analytics/providers/puzzle-analytics.provider.spec.ts
@@ -1,0 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { PuzzleAnalyticsProvider } from './puzzle-analytics.provider';
+import { AnalyticsEvent } from '../entities/analytics-event.entity';
+import { DateRangeDto } from '../dtos/date-range.dto';
+
+describe('PuzzleAnalyticsProvider', () => {
+  let provider: PuzzleAnalyticsProvider;
+  let qb: Record<string, jest.Mock>;
+  let mockRepo: { createQueryBuilder: jest.Mock };
+
+  beforeEach(async () => {
+    qb = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([]),
+    };
+    mockRepo = { createQueryBuilder: jest.fn(() => qb) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PuzzleAnalyticsProvider,
+        { provide: getRepositoryToken(AnalyticsEvent), useValue: mockRepo },
+      ],
+    }).compile();
+
+    provider = module.get<PuzzleAnalyticsProvider>(PuzzleAnalyticsProvider);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should be defined', () => {
+    expect(provider).toBeDefined();
+  });
+
+  it('returns zeroed stats when no events exist for the puzzle', async () => {
+    qb.getMany.mockResolvedValue([]);
+
+    const result = await provider.getPuzzleStats('puzzle-1');
+
+    expect(result).toEqual({
+      puzzleId: 'puzzle-1',
+      totalAttempts: 0,
+      successfulAttempts: 0,
+      failedAttempts: 0,
+      successRate: 0,
+      averageTimeSpent: 0,
+      uniqueUsers: 0,
+      startDate: undefined,
+      endDate: undefined,
+    });
+  });
+
+  it('computes stats correctly for multiple puzzle attempts', async () => {
+    const fakeEvents = [
+      {
+        id: '1',
+        eventType: 'puzzle_attempted',
+        userId: 'user-a',
+        entityId: 'puzzle-100',
+        payload: { puzzleId: 'puzzle-100', isCorrect: true, timeSpent: 30 },
+        timestamp: new Date('2024-01-10T10:00:00Z'),
+      },
+      {
+        id: '2',
+        eventType: 'puzzle_attempted',
+        userId: 'user-a',
+        entityId: 'puzzle-100',
+        payload: { puzzleId: 'puzzle-100', isCorrect: true, timeSpent: 50 },
+        timestamp: new Date('2024-01-11T10:00:00Z'),
+      },
+      {
+        id: '3',
+        eventType: 'puzzle_attempted',
+        userId: 'user-b',
+        entityId: 'puzzle-100',
+        payload: { puzzleId: 'puzzle-100', isCorrect: false, timeSpent: 40 },
+        timestamp: new Date('2024-01-12T10:00:00Z'),
+      },
+    ];
+
+    qb.getMany.mockResolvedValue(fakeEvents);
+
+    const dateQuery: DateRangeDto = {
+      start: new Date('2024-01-01T00:00:00Z'),
+      end: new Date('2024-01-31T00:00:00Z'),
+      _dateRange: true,
+    };
+
+    const result = await provider.getPuzzleStats('puzzle-100', dateQuery);
+
+    expect(result).toEqual({
+      puzzleId: 'puzzle-100',
+      totalAttempts: 3,
+      successfulAttempts: 2,
+      failedAttempts: 1,
+      successRate: 66.67,
+      averageTimeSpent: 40,
+      uniqueUsers: 2,
+      startDate: '2024-01-01',
+      endDate: '2024-01-31',
+    });
+  });
+});

--- a/backend/src/analytics/providers/puzzle-analytics.provider.ts
+++ b/backend/src/analytics/providers/puzzle-analytics.provider.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AnalyticsEvent } from '../entities/analytics-event.entity';
+import { DateRangeDto } from '../dtos/date-range.dto';
+import { PuzzleStatsResult } from '../dtos/analytics-metric-result.dto';
+
+@Injectable()
+export class PuzzleAnalyticsProvider {
+  constructor(
+    @InjectRepository(AnalyticsEvent)
+    private readonly analyticsEventRepository: Repository<AnalyticsEvent>,
+  ) {}
+
+  async getPuzzleStats(
+    puzzleId: string,
+    query?: DateRangeDto,
+  ): Promise<PuzzleStatsResult> {
+    const qb = this.analyticsEventRepository
+      .createQueryBuilder('e')
+      .where('e.eventType IN (:...eventTypes)', {
+        eventTypes: ['puzzle_attempted', 'first_puzzle_attempted'],
+      })
+      .andWhere(
+        '(e.entityId = :puzzleId OR e.payload::jsonb->>\'puzzleId\' = :puzzleId)',
+        { puzzleId },
+      );
+
+    if (query?.start) {
+      qb.andWhere('e.timestamp >= :start', { start: query.start });
+    }
+    if (query?.end) {
+      qb.andWhere('e.timestamp <= :end', { end: query.end });
+    }
+
+    const events = await qb.getMany();
+
+    const totalAttempts = events.length;
+    let successfulAttempts = 0;
+    let failedAttempts = 0;
+    let totalTimeSpent = 0;
+    const userSet = new Set<string>();
+
+    for (const ev of events) {
+      if (ev.userId) userSet.add(ev.userId);
+
+      const isCorrect = ev.payload?.isCorrect;
+      if (isCorrect === true) {
+        successfulAttempts++;
+      } else if (isCorrect === false) {
+        failedAttempts++;
+      }
+
+      if (typeof ev.payload?.timeSpent === 'number') {
+        totalTimeSpent += ev.payload.timeSpent;
+      }
+    }
+
+    const successRate =
+      totalAttempts > 0
+        ? Math.round((successfulAttempts / totalAttempts) * 100 * 100) / 100
+        : 0;
+
+    const averageTimeSpent =
+      totalAttempts > 0
+        ? Math.round((totalTimeSpent / totalAttempts) * 100) / 100
+        : 0;
+
+    return {
+      puzzleId,
+      totalAttempts,
+      successfulAttempts,
+      failedAttempts,
+      successRate,
+      averageTimeSpent,
+      uniqueUsers: userSet.size,
+      startDate: query?.start
+        ? query.start.toISOString().split('T')[0]
+        : undefined,
+      endDate: query?.end ? query.end.toISOString().split('T')[0] : undefined,
+    };
+  }
+}

--- a/backend/test/analytics.e2e-spec.ts
+++ b/backend/test/analytics.e2e-spec.ts
@@ -12,9 +12,13 @@ import { GetOnboardingFunnelProvider } from '../src/analytics/providers/get-onbo
 import { GetRetentionCurveProvider } from '../src/analytics/providers/get-retention-curve.provider';
 import { GetChurnRiskProvider } from '../src/analytics/providers/get-churn-risk.provider';
 import { ExportCsvProvider } from '../src/analytics/providers/export-csv.provider';
+import { PuzzleAnalyticsProvider } from '../src/analytics/providers/puzzle-analytics.provider';
 import { AnalyticsService } from '../src/analytics/analytics.service';
 import { AnalyticsAdminGuard } from '../src/analytics/guards/analytics-admin.guard';
-import { AnalyticsMetricResult } from '../src/analytics/dtos/analytics-metric-result.dto';
+import {
+  AnalyticsMetricResult,
+  PuzzleStatsResult,
+} from '../src/analytics/dtos/analytics-metric-result.dto';
 
 describe('GET /analytics/users/retention (e2e)', () => {
   let app: INestApplication<App>;
@@ -54,6 +58,7 @@ describe('GET /analytics/users/retention (e2e)', () => {
           useValue: mockGetRetentionCurveProvider,
         },
         { provide: GetChurnRiskProvider, useValue: {} },
+        { provide: PuzzleAnalyticsProvider, useValue: {} },
         { provide: ExportCsvProvider, useValue: mockExportCsvProvider },
         { provide: AnalyticsService, useValue: {} },
       ],
@@ -165,6 +170,143 @@ describe('GET /analytics/users/retention (e2e)', () => {
   });
 });
 
+describe('GET /analytics/puzzles/:id/stats (e2e)', () => {
+  let app: INestApplication<App>;
+
+  const mockPuzzleAnalyticsProvider = { getPuzzleStats: jest.fn() };
+
+  const fakePuzzleStatsResult: PuzzleStatsResult = {
+    puzzleId: 'puzzle-uuid-100',
+    totalAttempts: 10,
+    successfulAttempts: 7,
+    failedAttempts: 3,
+    successRate: 70,
+    averageTimeSpent: 45.2,
+    uniqueUsers: 6,
+    startDate: '2024-01-01',
+    endDate: '2024-01-31',
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [AnalyticsController],
+      providers: [
+        { provide: TrackEventProvider, useValue: {} },
+        { provide: GetOnboardingFunnelProvider, useValue: {} },
+        { provide: GetRetentionCurveProvider, useValue: {} },
+        { provide: GetChurnRiskProvider, useValue: {} },
+        {
+          provide: PuzzleAnalyticsProvider,
+          useValue: mockPuzzleAnalyticsProvider,
+        },
+        { provide: ExportCsvProvider, useValue: {} },
+        { provide: AnalyticsService, useValue: {} },
+      ],
+    })
+      .overrideGuard(AnalyticsAdminGuard)
+      .useValue({
+        canActivate: (context: ExecutionContext) => {
+          const req = context.switchToHttp().getRequest();
+          return req.headers['x-test-role'] === 'admin';
+        },
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 200 with the documented response shape for an admin caller', async () => {
+    mockPuzzleAnalyticsProvider.getPuzzleStats.mockResolvedValue(
+      fakePuzzleStatsResult,
+    );
+
+    const res = await request(app.getHttpServer())
+      .get('/analytics/puzzles/puzzle-uuid-100/stats')
+      .set('x-test-role', 'admin')
+      .query({
+        start: '2024-01-01T00:00:00.000Z',
+        end: '2024-01-31T00:00:00.000Z',
+      })
+      .expect(200);
+
+    expect(res.body).toEqual(fakePuzzleStatsResult);
+    expect(mockPuzzleAnalyticsProvider.getPuzzleStats).toHaveBeenCalledWith(
+      'puzzle-uuid-100',
+      expect.objectContaining({
+        start: new Date('2024-01-01T00:00:00.000Z'),
+        end: new Date('2024-01-31T00:00:00.000Z'),
+      }),
+    );
+  });
+
+  it('returns 403 for a caller without the admin role', async () => {
+    await request(app.getHttpServer())
+      .get('/analytics/puzzles/puzzle-uuid-100/stats')
+      .expect(403);
+
+    expect(mockPuzzleAnalyticsProvider.getPuzzleStats).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 with a clear validation message for an invalid granularity', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/analytics/puzzles/puzzle-uuid-100/stats')
+      .set('x-test-role', 'admin')
+      .query({ granularity: 'century' })
+      .expect(400);
+
+    expect(res.body.message).toEqual(
+      expect.arrayContaining([expect.stringContaining('granularity')]),
+    );
+    expect(mockPuzzleAnalyticsProvider.getPuzzleStats).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when start is after end', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/analytics/puzzles/puzzle-uuid-100/stats')
+      .set('x-test-role', 'admin')
+      .query({
+        start: '2024-02-01T00:00:00.000Z',
+        end: '2024-01-01T00:00:00.000Z',
+      })
+      .expect(400);
+
+    expect(res.body.message).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'start date must be before or equal to end date',
+        ),
+      ]),
+    );
+    expect(mockPuzzleAnalyticsProvider.getPuzzleStats).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an unrecognized query param', async () => {
+    await request(app.getHttpServer())
+      .get('/analytics/puzzles/puzzle-uuid-100/stats')
+      .set('x-test-role', 'admin')
+      .query({ unknownParam: 'nope' })
+      .expect(400);
+
+    expect(mockPuzzleAnalyticsProvider.getPuzzleStats).not.toHaveBeenCalled();
+  });
+});
+
 describe('GET /analytics/export (e2e)', () => {
   let app: INestApplication<App>;
 
@@ -178,6 +320,7 @@ describe('GET /analytics/export (e2e)', () => {
         { provide: GetOnboardingFunnelProvider, useValue: {} },
         { provide: GetRetentionCurveProvider, useValue: {} },
         { provide: GetChurnRiskProvider, useValue: {} },
+        { provide: PuzzleAnalyticsProvider, useValue: {} },
         { provide: ExportCsvProvider, useValue: mockExportCsvProvider },
         { provide: AnalyticsService, useValue: {} },
       ],


### PR DESCRIPTION
Closes #531 

## Description
Adds the `GET /analytics/puzzles/:id/stats` controller route to expose detailed single-puzzle statistics (total attempts, successful vs failed attempts, success rate percentage, average time spent, and unique users). Implements `PuzzleAnalyticsProvider`, validates query parameters with `DateRangeDto`, restricts access with `AnalyticsAdminGuard`, and provides full end-to-end (e2e) test coverage.

## Key Changes
- **Response DTOs & Export Metric**:
  - Added `PuzzleStatsResult` response class to `analytics-metric-result.dto.ts`.
  - Added `PUZZLE_STATS = 'puzzle_stats'` to `ExportMetric` in `analytics-query.dto.ts`.
- **Analytics Provider**:
  - Implemented `PuzzleAnalyticsProvider` in `puzzle-analytics.provider.ts` (re-exported via `puzzle-analytics.entity.ts`).
  - Queries `AnalyticsEvent` repository for `puzzle_attempted` and `first_puzzle_attempted` events filtered by `:id` and date range window.
- **Controller Route & Module**:
  - Exposed `GET /analytics/puzzles/:id/stats` in `AnalyticsController` guarded by `AnalyticsAdminGuard` and annotated with Swagger metadata.
  - Registered `PuzzleAnalyticsProvider` in `AnalyticsModule`.
- **Testing**:
  - Created unit tests in `puzzle-analytics.provider.spec.ts`.
  - Added `describe('GET /analytics/puzzles/:id/stats (e2e)')` test suite to `backend/test/analytics.e2e-spec.ts`.

## Acceptance Criteria Checklist
- [x] `GET /analytics/puzzles/:id/stats` returns `200 OK` with the documented response shape for admin callers.
- [x] Invalid query parameters return `400 Bad Request` with clear validation error messages.
- [x] Route requires an authenticated admin role via `AnalyticsAdminGuard` (returns `403` otherwise).
- [x] Route is fully covered by e2e tests in `backend/test/analytics.e2e-spec.ts`.

## Verification & Testing Performed
### Unit Tests (10/10 Passed)
```bash
npx jest src/analytics/providers/puzzle-analytics.provider.spec.ts src/analytics/providers/export-csv.provider.spec.ts