### PR TITLE
Add AnalyticsAdminGuard restricting sensitive analytics endpoints

### DIFF
--- a/backend/src/analytics/controllers/analytics.controller.ts
+++ b/backend/src/analytics/controllers/analytics.controller.ts
@@ -23,6 +23,7 @@ import {
   PuzzleStatsResult,
 } from '../dtos/analytics-metric-result.dto';
 import { AnalyticsAdminGuard } from '../guards/analytics-admin.guard';
+import { AnalyticsAdmin } from '../../roles/roles.decorator';
 
 @ApiTags('Analytics')
 @Controller('analytics')
@@ -58,6 +59,7 @@ export class AnalyticsController {
   }
 
   @Get('users/retention')
+  @AnalyticsAdmin()
   @UseGuards(AnalyticsAdminGuard)
   @ApiOperation({ summary: 'Get the user retention curve (admin only)' })
   @ApiResponse({ status: 200, type: AnalyticsMetricResult })
@@ -66,6 +68,7 @@ export class AnalyticsController {
   }
 
   @Get('users/churn-risk')
+  @AnalyticsAdmin()
   @UseGuards(AnalyticsAdminGuard)
   @ApiOperation({ summary: 'Get per-user churn risk scores (admin only)' })
   @ApiExtraModels(AnalyticsMetricResult, ChurnRiskDataPoint)
@@ -92,6 +95,7 @@ export class AnalyticsController {
   }
 
   @Get('puzzles/:id/stats')
+  @AnalyticsAdmin()
   @UseGuards(AnalyticsAdminGuard)
   @ApiOperation({ summary: 'Get detailed stats for a single puzzle (admin only)' })
   @ApiResponse({ status: 200, type: PuzzleStatsResult })
@@ -103,6 +107,7 @@ export class AnalyticsController {
   }
 
   @Get('export')
+  @AnalyticsAdmin()
   @UseGuards(AnalyticsAdminGuard)
   @ApiOperation({
     summary: 'Export a chosen analytics metric over a date range (admin only)',

--- a/backend/src/analytics/guards/analytics-admin.guard.spec.ts
+++ b/backend/src/analytics/guards/analytics-admin.guard.spec.ts
@@ -1,0 +1,72 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AnalyticsAdminGuard } from './analytics-admin.guard';
+import { ANALYTICS_ADMIN_KEY } from '../../roles/roles.decorator';
+import { userRole } from '../../users/enums/userRole.enum';
+
+describe('AnalyticsAdminGuard', () => {
+  let guard: AnalyticsAdminGuard;
+  let reflector: Reflector;
+
+  const mockContext = (userRoleValue?: string) => {
+    const user = userRoleValue ? { userRole: userRoleValue } : undefined;
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({ user }),
+      }),
+      getHandler: () => null,
+      getClass: () => null,
+    } as any;
+  };
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new AnalyticsAdminGuard(reflector);
+  });
+
+  describe('when route has @AnalyticsAdmin() decorator', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(true);
+    });
+
+    it('allows admin users', () => {
+      const context = mockContext(userRole.ADMIN);
+      expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it('throws ForbiddenException for non-admin users', () => {
+      const context = mockContext(userRole.USER);
+      expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+    });
+
+    it('throws ForbiddenException for guest users', () => {
+      const context = mockContext(userRole.GUEST);
+      expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+    });
+
+    it('throws ForbiddenException when no user is attached to request', () => {
+      const context = mockContext(undefined);
+      expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+    });
+  });
+
+  describe('when route lacks @AnalyticsAdmin() decorator', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(reflector, 'getAllAndOverride')
+        .mockReturnValue(false);
+    });
+
+    it('allows any user through', () => {
+      const context = mockContext(userRole.USER);
+      expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it('allows unauthenticated requests through', () => {
+      const context = mockContext(undefined);
+      expect(guard.canActivate(context)).toBe(true);
+    });
+  });
+});

--- a/backend/src/analytics/guards/analytics-admin.guard.ts
+++ b/backend/src/analytics/guards/analytics-admin.guard.ts
@@ -4,20 +4,23 @@ import {
   ForbiddenException,
   Injectable,
 } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ANALYTICS_ADMIN_KEY } from '../../roles/roles.decorator';
 import { userRole } from '../../users/enums/userRole.enum';
 import { DecodedUserPayload } from '../../auth/middleware/jwt-auth.middleware';
 
-/**
- * Restricts analytics routes that expose sensitive aggregate data
- * (e.g. retention curves) to admin users.
- *
- * Relies on `JwtAuthMiddleware`, which runs globally and attaches
- * the decoded token payload to `req.user` before any guard executes.
- * This guard does not re-verify the token -- it only checks role.
- */
 @Injectable()
 export class AnalyticsAdminGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
   canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<boolean>(
+      ANALYTICS_ADMIN_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!requiredRoles) return true;
+
     const request = context
       .switchToHttp()
       .getRequest<{ user?: DecodedUserPayload }>();

--- a/backend/src/roles/roles.decorator.ts
+++ b/backend/src/roles/roles.decorator.ts
@@ -3,3 +3,6 @@ import { userRole } from '../users/enums/userRole.enum';
 
 export const ROLES_KEY = 'roles';
 export const Roles = (...roles: userRole[]) => SetMetadata(ROLES_KEY, roles);
+
+export const ANALYTICS_ADMIN_KEY = 'analytics_admin';
+export const AnalyticsAdmin = () => SetMetadata(ANALYTICS_ADMIN_KEY, true);


### PR DESCRIPTION
## Description

Adds an `AnalyticsAdminGuard` that restricts sensitive analytics endpoints (churn-risk, exports, raw event listing) to admin users only, following the pattern of `backend/src/roles/roles.guard.ts`.

## Changes

- **roles.decorator.ts**: Added `ANALYTICS_ADMIN_KEY` and `AnalyticsAdmin()` decorator
- **analytics-admin.guard.ts**: Refactored to use `Reflector` pattern (matching `RolesGuard`)
- **analytics.controller.ts**: Added `@AnalyticsAdmin()` decorator to guarded routes
- **analytics-admin.guard.spec.ts**: Unit tests with allow (admin) and deny (user/guest/unauthenticated) cases

## Acceptance Criteria
- Non-admin users receive a 403 on guarded routes ✓
- Admin users pass through normally ✓
- Guard is unit tested with both allow and deny cases ✓

Closes #551