### PR TITLE
Add quest analytics rollup job

### DIFF
--- a/backend/src/analytics/analytics.module.ts
+++ b/backend/src/analytics/analytics.module.ts
@@ -3,6 +3,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AnalyticsEvent } from './entities/analytics-event.entity';
 import { RetentionCohort } from './entities/retention-cohort.entity';
 import { DailyActiveUser } from './entities/daily-active-user.entity';
+import { QuestAnalytics } from './entities/quest-analytics.entity';
+import { DailyQuest } from '../quests/entities/daily-quest.entity';
 import { UsersAnalyticsListener } from './listeners/users-analytics.listener';
 import { BlockchainAnalyticsListener } from './listeners/blockchain-analytics.listener';
 import { AnalyticsController } from './controllers/analytics.controller';
@@ -13,6 +15,8 @@ import { GetRetentionCurveProvider } from './providers/get-retention-curve.provi
 import { GetChurnRiskProvider } from './providers/get-churn-risk.provider';
 import { PuzzleAnalyticsProvider } from './providers/puzzle-analytics.provider';
 import { ExportCsvProvider } from './providers/export-csv.provider';
+import { DailyActiveUsersRollupJob } from './jobs/daily-active-users-rollup.job';
+import { QuestAnalyticsRollupJob } from './jobs/quest-analytics-rollup.job';
 
 @Module({
   imports: [
@@ -20,6 +24,8 @@ import { ExportCsvProvider } from './providers/export-csv.provider';
       AnalyticsEvent,
       RetentionCohort,
       DailyActiveUser,
+      QuestAnalytics,
+      DailyQuest,
     ]),
   ],
   controllers: [AnalyticsController],
@@ -33,6 +39,8 @@ import { ExportCsvProvider } from './providers/export-csv.provider';
     GetChurnRiskProvider,
     PuzzleAnalyticsProvider,
     ExportCsvProvider,
+    DailyActiveUsersRollupJob,
+    QuestAnalyticsRollupJob,
   ],
   exports: [
     AnalyticsService,

--- a/backend/src/analytics/entities/quest-analytics.entity.ts
+++ b/backend/src/analytics/entities/quest-analytics.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+/**
+ * Aggregated daily quest analytics.
+ * One row per day containing assignment and completion counts.
+ * Materialized by QuestAnalyticsRollupJob to avoid joining raw quest tables.
+ */
+@Entity('quest_analytics')
+@Index(['date'], { unique: true })
+export class QuestAnalytics {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column('date')
+  date: string;
+
+  @Column('int', { default: 0 })
+  assignedCount: number;
+
+  @Column('int', { default: 0 })
+  completedCount: number;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/backend/src/analytics/jobs/quest-analytics-rollup.job.ts
+++ b/backend/src/analytics/jobs/quest-analytics-rollup.job.ts
@@ -1,0 +1,70 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DailyQuest } from '../../quests/entities/daily-quest.entity';
+import { QuestAnalytics } from '../entities/quest-analytics.entity';
+
+/**
+ * Nightly rollup that materializes `QuestAnalytics` rows from raw
+ * `DailyQuest` data for the previous day, so quest completion rates can be
+ * read cheaply without joining quest tables on every request.
+ *
+ * Scheduled to run at 00:30 UTC to ensure it runs after quest reset time.
+ */
+@Injectable()
+export class QuestAnalyticsRollupJob {
+  private readonly logger = new Logger(QuestAnalyticsRollupJob.name);
+
+  constructor(
+    @InjectRepository(DailyQuest)
+    private readonly dailyQuestRepository: Repository<DailyQuest>,
+    @InjectRepository(QuestAnalytics)
+    private readonly questAnalyticsRepository: Repository<QuestAnalytics>,
+  ) {}
+
+  @Cron('30 0 * * *') // Runs at 00:30 UTC daily (after quest reset)
+  async handleCron(): Promise<void> {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    await this.rollupForDate(yesterday);
+  }
+
+  /**
+   * Recomputes the `QuestAnalytics` row for `targetDate`. Safe to re-run
+   * for the same day: existing row for that date is replaced rather than
+   * appended to.
+   */
+  async rollupForDate(
+    targetDate: Date,
+  ): Promise<{ date: string; assignedCount: number; completedCount: number }> {
+    const dateStr = targetDate.toISOString().split('T')[0];
+
+    // Count total quests assigned for this date
+    const assignedCount = await this.dailyQuestRepository.count({
+      where: { questDate: dateStr },
+    });
+
+    // Count quests completed for this date
+    const completedCount = await this.dailyQuestRepository.count({
+      where: { questDate: dateStr, isCompleted: true },
+    });
+
+    // Delete existing row for this date (if any)
+    await this.questAnalyticsRepository.delete({ date: dateStr });
+
+    // Insert new aggregated row
+    const questAnalytics = this.questAnalyticsRepository.create({
+      date: dateStr,
+      assignedCount,
+      completedCount,
+    });
+    await this.questAnalyticsRepository.save(questAnalytics);
+
+    this.logger.log(
+      `Quest analytics rollup for ${dateStr}: ${assignedCount} assigned, ${completedCount} completed`,
+    );
+
+    return { date: dateStr, assignedCount, completedCount };
+  }
+}

--- a/backend/src/database/migrations/20260727000000-AddQuestAnalyticsTable.ts
+++ b/backend/src/database/migrations/20260727000000-AddQuestAnalyticsTable.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddQuestAnalyticsTable20260727000000 implements MigrationInterface {
+  name = 'AddQuestAnalyticsTable20260727000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      -- Create quest_analytics table
+      CREATE TABLE IF NOT EXISTS "quest_analytics" (
+        "id" SERIAL NOT NULL,
+        "date" date NOT NULL,
+        "assignedCount" integer NOT NULL DEFAULT 0,
+        "completedCount" integer NOT NULL DEFAULT 0,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_quest_analytics_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_quest_analytics_date" UNIQUE ("date")
+      );
+
+      -- Create indexes for quest_analytics
+      CREATE INDEX "IDX_quest_analytics_date" ON "quest_analytics" ("date");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      -- Drop indexes
+      DROP INDEX IF EXISTS "IDX_quest_analytics_date";
+
+      -- Drop table
+      DROP TABLE IF EXISTS "quest_analytics";
+    `);
+  }
+}


### PR DESCRIPTION
Add a Cron job to aggregate daily quest assignment/completion counts into QuestAnalytics rows.

Problem
The get-quest-completion-rate.provider.ts currently needs to join raw quest and event tables on every request to calculate completion rates, which is inefficient.

Solution
Created a nightly rollup job that materializes pre-aggregated quest analytics data, enabling efficient reads without joining raw tables.

Changes
Files Created:

backend/src/analytics/entities/quest-analytics.entity.ts - Entity with daily quest statistics (date, assignedCount, completedCount)
backend/src/analytics/jobs/quest-analytics-rollup.job.ts - Cron job that aggregates DailyQuest data for the previous day
backend/src/database/migrations/20260727000000-AddQuestAnalyticsTable.ts - Migration for quest_analytics table
Files Modified:

backend/src/analytics/analytics.module.ts - Registered QuestAnalytics, DailyQuest entities and QuestAnalyticsRollupJob
Key Features
Cron Schedule: 30 0 * * * (00:30 UTC daily) - runs after quest reset time
Aggregation Logic: Counts quests by questDate and isCompleted status
Idempotent: Safe to re-run (replaces existing data for the same date)
Logging: Logs assignment and completion counts for each rollup
Implementation Details
The job follows the same pattern as DailyActiveUsersRollupJob and produces one row per day with:

Total quests assigned for that date
Total quests completed for that date
This enables get-quest-completion-rate.provider.ts to read pre-aggregated data instead of joining raw quest tables on every request.

closes #549