### PR TITLE
feat(challenge-attempt): implement ChallengeAttempt domain model and service

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -32,6 +32,7 @@ import { UsersService } from './users/providers/users.service';
 import { GeolocationMiddleware } from './common/middleware/geolocation.middleware';
 import { HealthModule } from './health/health.module';
 import { AnalyticsModule } from './analytics/analytics.module';
+import { ChallengeAttemptModule } from './challenge-attempt/challenge-attempt.module';
 
 // const ENV = process.env.NODE_ENV;
 // console.log('NODE_ENV:', process.env.NODE_ENV);
@@ -119,6 +120,7 @@ import { AnalyticsModule } from './analytics/analytics.module';
       }),
     }),
     HealthModule,
+    ChallengeAttemptModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/challenge-attempt/challenge-attempt.module.ts
+++ b/backend/src/challenge-attempt/challenge-attempt.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ChallengeAttempt } from './entities/challenge-attempt.entity';
+import { Puzzle } from '../puzzles/entities/puzzle.entity';
+import { ChallengeAttemptService } from './providers/challenge-attempt.service';
+import { ChallengeAttemptController } from './controllers/challenge-attempt.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ChallengeAttempt, Puzzle])],
+  controllers: [ChallengeAttemptController],
+  providers: [ChallengeAttemptService],
+  exports: [ChallengeAttemptService],
+})
+export class ChallengeAttemptModule {}

--- a/backend/src/challenge-attempt/controllers/challenge-attempt.controller.ts
+++ b/backend/src/challenge-attempt/controllers/challenge-attempt.controller.ts
@@ -1,0 +1,226 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { ChallengeAttemptService } from '../providers/challenge-attempt.service';
+import { CreateChallengeAttemptDto } from '../dtos/create-challenge-attempt.dto';
+import { SubmitAttemptDto } from '../dtos/submit-attempt.dto';
+import { RevealSolutionDto } from '../dtos/reveal-solution.dto';
+import { UseHintDto } from '../dtos/use-hint.dto';
+import { ChallengeAttempt } from '../entities/challenge-attempt.entity';
+
+@ApiTags('challenge-attempts')
+@Controller('challenge-attempts')
+export class ChallengeAttemptController {
+  constructor(
+    private readonly challengeAttemptService: ChallengeAttemptService,
+  ) {}
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // POST /challenge-attempts  →  start a new attempt
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Start a new challenge attempt',
+    description:
+      'Creates a new ChallengeAttempt record in STARTED state for the given user and challenge. ' +
+      'Optionally links the attempt to a game session via sessionId.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Attempt started successfully',
+    type: ChallengeAttempt,
+  })
+  @ApiResponse({ status: 400, description: 'Validation failed' })
+  @ApiResponse({ status: 404, description: 'Challenge not found' })
+  async createAttempt(
+    @Body() dto: CreateChallengeAttemptDto,
+  ): Promise<ChallengeAttempt> {
+    return this.challengeAttemptService.createAttempt(dto);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // POST /challenge-attempts/submit  →  submit an answer
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  @Post('submit')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Submit an answer for an existing attempt',
+    description:
+      'Records the player answer, validates it against the correct answer, ' +
+      'calculates the score (with time bonus), and transitions the attempt ' +
+      'to CORRECT or INCORRECT.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Answer submitted; attempt updated with result',
+    type: ChallengeAttempt,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Attempt already in terminal state or validation failed',
+  })
+  @ApiResponse({ status: 404, description: 'Attempt or challenge not found' })
+  async submitAttempt(
+    @Body() dto: SubmitAttemptDto,
+  ): Promise<ChallengeAttempt> {
+    return this.challengeAttemptService.submitAttempt(dto);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // PATCH /challenge-attempts/hint  →  record hint usage
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  @Patch('hint')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Record a hint usage for an attempt',
+    description:
+      'Increments the hintsUsed counter on the attempt. ' +
+      'Does not return the hint content — that is fetched separately from the challenge.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Hint usage recorded',
+    type: ChallengeAttempt,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Attempt already in terminal state',
+  })
+  @ApiResponse({ status: 404, description: 'Attempt not found' })
+  async useHint(@Body() dto: UseHintDto): Promise<ChallengeAttempt> {
+    return this.challengeAttemptService.useHint(dto);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // PATCH /challenge-attempts/reveal  →  reveal solution
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  @Patch('reveal')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Reveal the solution for an attempt',
+    description:
+      'Marks solutionRevealed = true, zeroes the score, and if the attempt is ' +
+      'still STARTED it is moved to INCORRECT.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Solution revealed; attempt updated',
+    type: ChallengeAttempt,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Attempt already in terminal state',
+  })
+  @ApiResponse({ status: 404, description: 'Attempt not found' })
+  async revealSolution(
+    @Body() dto: RevealSolutionDto,
+  ): Promise<ChallengeAttempt> {
+    return this.challengeAttemptService.revealSolution(dto);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // PATCH /challenge-attempts/:id/expire  →  expire an attempt
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  @Patch(':id/expire')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Expire an attempt',
+    description:
+      'Marks the attempt as EXPIRED when the allowed time has elapsed. ' +
+      'Typically called by the server-side scheduler or client when timer fires.',
+  })
+  @ApiParam({ name: 'id', description: 'UUID of the attempt to expire' })
+  @ApiResponse({
+    status: 200,
+    description: 'Attempt expired successfully',
+    type: ChallengeAttempt,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Attempt already in terminal state',
+  })
+  @ApiResponse({ status: 404, description: 'Attempt not found' })
+  async expireAttempt(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<ChallengeAttempt> {
+    return this.challengeAttemptService.expireAttempt(id);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // GET /challenge-attempts/:id  →  get a single attempt
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get a single attempt by ID' })
+  @ApiParam({ name: 'id', description: 'UUID of the attempt' })
+  @ApiResponse({
+    status: 200,
+    description: 'Attempt retrieved successfully',
+    type: ChallengeAttempt,
+  })
+  @ApiResponse({ status: 404, description: 'Attempt not found' })
+  async findById(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<ChallengeAttempt> {
+    return this.challengeAttemptService.findById(id);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // GET /challenge-attempts/user/:userId  →  all attempts for a user
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  @Get('user/:userId')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get all attempts for a given user' })
+  @ApiParam({ name: 'userId', description: 'UUID of the user' })
+  @ApiResponse({
+    status: 200,
+    description: 'Attempts retrieved successfully',
+    type: [ChallengeAttempt],
+  })
+  async findByUser(
+    @Param('userId', ParseUUIDPipe) userId: string,
+  ): Promise<ChallengeAttempt[]> {
+    return this.challengeAttemptService.findByUser(userId);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // GET /challenge-attempts/session/:sessionId  →  all attempts in a session
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  @Get('session/:sessionId')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get all attempts belonging to a game session' })
+  @ApiParam({ name: 'sessionId', description: 'Session identifier string' })
+  @ApiResponse({
+    status: 200,
+    description: 'Attempts retrieved successfully',
+    type: [ChallengeAttempt],
+  })
+  async findBySession(
+    @Param('sessionId') sessionId: string,
+  ): Promise<ChallengeAttempt[]> {
+    return this.challengeAttemptService.findBySession(sessionId);
+  }
+}

--- a/backend/src/challenge-attempt/dtos/create-challenge-attempt.dto.ts
+++ b/backend/src/challenge-attempt/dtos/create-challenge-attempt.dto.ts
@@ -1,0 +1,20 @@
+import { IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
+
+/**
+ * DTO for starting a new challenge attempt.
+ *
+ * Minimal data required: who is attempting which challenge.
+ * sessionId is optional and links this attempt to a game session.
+ */
+export class CreateChallengeAttemptDto {
+  @IsUUID('4', { message: 'userId must be a valid UUID v4' })
+  userId: string;
+
+  @IsUUID('4', { message: 'challengeId must be a valid UUID v4' })
+  challengeId: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  sessionId?: string;
+}

--- a/backend/src/challenge-attempt/dtos/reveal-solution.dto.ts
+++ b/backend/src/challenge-attempt/dtos/reveal-solution.dto.ts
@@ -1,0 +1,12 @@
+import { IsUUID } from 'class-validator';
+
+/**
+ * DTO for revealing the solution of an active attempt.
+ *
+ * Revealing the solution marks the attempt as INCORRECT and
+ * sets solutionRevealed = true to prevent scoring.
+ */
+export class RevealSolutionDto {
+  @IsUUID('4', { message: 'attemptId must be a valid UUID v4' })
+  attemptId: string;
+}

--- a/backend/src/challenge-attempt/dtos/submit-attempt.dto.ts
+++ b/backend/src/challenge-attempt/dtos/submit-attempt.dto.ts
@@ -1,0 +1,20 @@
+import { IsInt, IsNotEmpty, IsString, IsUUID, Min } from 'class-validator';
+
+/**
+ * DTO for submitting an answer to an existing attempt.
+ *
+ * timeSpent is in seconds, measured client-side from when the player
+ * opened the challenge to when they pressed submit.
+ */
+export class SubmitAttemptDto {
+  @IsUUID('4', { message: 'attemptId must be a valid UUID v4' })
+  attemptId: string;
+
+  @IsString()
+  @IsNotEmpty({ message: 'answer must not be empty' })
+  answer: string;
+
+  @IsInt()
+  @Min(0, { message: 'timeSpent must be a non-negative integer (seconds)' })
+  timeSpent: number;
+}

--- a/backend/src/challenge-attempt/dtos/use-hint.dto.ts
+++ b/backend/src/challenge-attempt/dtos/use-hint.dto.ts
@@ -1,0 +1,12 @@
+import { IsUUID } from 'class-validator';
+
+/**
+ * DTO for recording that a player used a hint on an attempt.
+ *
+ * Each use increments hintsUsed on the attempt; the actual hint content
+ * is fetched by the caller separately (e.g. from the Puzzle entity).
+ */
+export class UseHintDto {
+  @IsUUID('4', { message: 'attemptId must be a valid UUID v4' })
+  attemptId: string;
+}

--- a/backend/src/challenge-attempt/entities/challenge-attempt.entity.ts
+++ b/backend/src/challenge-attempt/entities/challenge-attempt.entity.ts
@@ -1,0 +1,94 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../../users/user.entity';
+import { Puzzle } from '../../puzzles/entities/puzzle.entity';
+import { AttemptStatus } from '../enums/attempt-status.enum';
+
+/**
+ * ChallengeAttempt tracks a player's interaction with a single challenge/puzzle.
+ *
+ * Each attempt belongs to:
+ * - A specific user (userId)
+ * - A specific challenge/puzzle (challengeId)
+ * - Optionally a game session (sessionId) for multiplayer / quest grouping
+ *
+ * Lifecycle states: STARTED → SUBMITTED → CORRECT | INCORRECT | EXPIRED
+ */
+@Entity('challenge_attempts')
+@Index(['userId', 'challengeId'])
+@Index(['sessionId'])
+@Index(['status'])
+@Index(['userId', 'startedAt'])
+export class ChallengeAttempt {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /**
+   * Optional session identifier for grouping attempts (e.g. a daily quest
+   * run, a multiplayer lobby, or a timed training session).
+   */
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  sessionId?: string;
+
+  /** FK to the user who made this attempt. */
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE', eager: false })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  /** FK to the puzzle / challenge that was attempted. */
+  @Column({ type: 'uuid' })
+  challengeId: string;
+
+  @ManyToOne(() => Puzzle, { onDelete: 'CASCADE', eager: false })
+  @JoinColumn({ name: 'challengeId' })
+  challenge: Puzzle;
+
+  /** The answer the player submitted (null until submitted). */
+  @Column({ type: 'text', nullable: true })
+  answer?: string;
+
+  /** Current lifecycle state of the attempt. */
+  @Column({
+    type: 'enum',
+    enum: AttemptStatus,
+    default: AttemptStatus.STARTED,
+  })
+  status: AttemptStatus;
+
+  /** Score awarded for this attempt (0 until graded). */
+  @Column({ type: 'int', default: 0 })
+  score: number;
+
+  /**
+   * Seconds elapsed from startedAt to submittedAt.
+   * Updated automatically on submission.
+   */
+  @Column({ type: 'int', default: 0 })
+  timeSpent: number;
+
+  /** Number of hints the player has consumed for this attempt. */
+  @Column({ type: 'int', default: 0 })
+  hintsUsed: number;
+
+  /** Whether the player chose to reveal the solution. */
+  @Column({ type: 'boolean', default: false })
+  solutionRevealed: boolean;
+
+  /** When the attempt was created / player started the challenge. */
+  @CreateDateColumn({ name: 'started_at', type: 'timestamptz' })
+  startedAt: Date;
+
+  /** When the player submitted their answer (null until submitted). */
+  @Column({ name: 'submitted_at', type: 'timestamptz', nullable: true })
+  submittedAt?: Date;
+}

--- a/backend/src/challenge-attempt/enums/attempt-status.enum.ts
+++ b/backend/src/challenge-attempt/enums/attempt-status.enum.ts
@@ -1,0 +1,7 @@
+export enum AttemptStatus {
+  STARTED = 'STARTED',
+  SUBMITTED = 'SUBMITTED',
+  CORRECT = 'CORRECT',
+  INCORRECT = 'INCORRECT',
+  EXPIRED = 'EXPIRED',
+}

--- a/backend/src/challenge-attempt/providers/challenge-attempt.service.spec.ts
+++ b/backend/src/challenge-attempt/providers/challenge-attempt.service.spec.ts
@@ -1,0 +1,591 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { ChallengeAttemptService } from './challenge-attempt.service';
+import { ChallengeAttempt } from '../entities/challenge-attempt.entity';
+import { Puzzle } from '../../puzzles/entities/puzzle.entity';
+import { AttemptStatus } from '../enums/attempt-status.enum';
+import { CreateChallengeAttemptDto } from '../dtos/create-challenge-attempt.dto';
+import { SubmitAttemptDto } from '../dtos/submit-attempt.dto';
+import { RevealSolutionDto } from '../dtos/reveal-solution.dto';
+import { UseHintDto } from '../dtos/use-hint.dto';
+
+/** Helper: builds a minimal Puzzle stub */
+function makePuzzle(overrides?: Partial<Puzzle>): Puzzle {
+  return {
+    id: 'puzzle-uuid-1',
+    question: 'What is 2+2?',
+    options: ['1', '2', '3', '4'],
+    correctAnswer: '4',
+    points: 100,
+    timeLimit: 60,
+    difficulty: 'BEGINNER' as any,
+    categoryId: 'cat-1',
+    category: null as any,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    explanation: null as any,
+    progressRecords: [],
+    ...overrides,
+  };
+}
+
+/** Helper: builds a minimal ChallengeAttempt stub */
+function makeAttempt(overrides?: Partial<ChallengeAttempt>): ChallengeAttempt {
+  return {
+    id: 'attempt-uuid-1',
+    userId: 'user-uuid-1',
+    challengeId: 'puzzle-uuid-1',
+    sessionId: undefined,
+    answer: undefined,
+    status: AttemptStatus.STARTED,
+    score: 0,
+    timeSpent: 0,
+    hintsUsed: 0,
+    solutionRevealed: false,
+    startedAt: new Date('2026-01-01T10:00:00Z'),
+    submittedAt: undefined,
+    user: null as any,
+    challenge: null as any,
+    ...overrides,
+  };
+}
+
+describe('ChallengeAttemptService', () => {
+  let service: ChallengeAttemptService;
+  let attemptRepo: jest.Mocked<Repository<ChallengeAttempt>>;
+  let puzzleRepo: jest.Mocked<Repository<Puzzle>>;
+
+  beforeEach(async () => {
+    const mockAttemptRepo: Partial<jest.Mocked<Repository<ChallengeAttempt>>> =
+      {
+        create: jest.fn(),
+        save: jest.fn(),
+        findOneBy: jest.fn(),
+        find: jest.fn(),
+        existsBy: jest.fn(),
+      };
+
+    const mockPuzzleRepo: Partial<jest.Mocked<Repository<Puzzle>>> = {
+      existsBy: jest.fn(),
+      findOneBy: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChallengeAttemptService,
+        {
+          provide: getRepositoryToken(ChallengeAttempt),
+          useValue: mockAttemptRepo,
+        },
+        {
+          provide: getRepositoryToken(Puzzle),
+          useValue: mockPuzzleRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ChallengeAttemptService>(ChallengeAttemptService);
+    attemptRepo = module.get(getRepositoryToken(ChallengeAttempt));
+    puzzleRepo = module.get(getRepositoryToken(Puzzle));
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Basic instantiation
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // createAttempt
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('createAttempt', () => {
+    const dto: CreateChallengeAttemptDto = {
+      userId: 'user-uuid-1',
+      challengeId: 'puzzle-uuid-1',
+      sessionId: 'session-abc',
+    };
+
+    it('should create and return a STARTED attempt', async () => {
+      const newAttempt = makeAttempt({ sessionId: dto.sessionId });
+      puzzleRepo.existsBy!.mockResolvedValue(true);
+      attemptRepo.create!.mockReturnValue(newAttempt);
+      attemptRepo.save!.mockResolvedValue(newAttempt);
+
+      const result = await service.createAttempt(dto);
+
+      expect(puzzleRepo.existsBy).toHaveBeenCalledWith({
+        id: dto.challengeId,
+      });
+      expect(attemptRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: dto.userId,
+          challengeId: dto.challengeId,
+          sessionId: dto.sessionId,
+          status: AttemptStatus.STARTED,
+          score: 0,
+          hintsUsed: 0,
+          solutionRevealed: false,
+        }),
+      );
+      expect(attemptRepo.save).toHaveBeenCalledWith(newAttempt);
+      expect(result.status).toBe(AttemptStatus.STARTED);
+    });
+
+    it('should create an attempt without a sessionId when omitted', async () => {
+      const noSessionDto: CreateChallengeAttemptDto = {
+        userId: 'user-uuid-1',
+        challengeId: 'puzzle-uuid-1',
+      };
+      const newAttempt = makeAttempt({ sessionId: undefined });
+      puzzleRepo.existsBy!.mockResolvedValue(true);
+      attemptRepo.create!.mockReturnValue(newAttempt);
+      attemptRepo.save!.mockResolvedValue(newAttempt);
+
+      const result = await service.createAttempt(noSessionDto);
+      expect(result.sessionId).toBeUndefined();
+    });
+
+    it('should throw NotFoundException when the challenge does not exist', async () => {
+      puzzleRepo.existsBy!.mockResolvedValue(false);
+
+      await expect(service.createAttempt(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(attemptRepo.create).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // submitAttempt
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('submitAttempt', () => {
+    const dto: SubmitAttemptDto = {
+      attemptId: 'attempt-uuid-1',
+      answer: '4',
+      timeSpent: 30,
+    };
+
+    it('should mark attempt CORRECT and award score for a correct answer', async () => {
+      const attempt = makeAttempt();
+      const puzzle = makePuzzle();
+      const savedAttempt = makeAttempt({
+        status: AttemptStatus.CORRECT,
+        answer: '4',
+        timeSpent: 30,
+        score: 125, // 100 * (1 + (60-30)/60*0.5) = 100 * 1.25 = 125
+        submittedAt: new Date(),
+      });
+
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      puzzleRepo.findOneBy!.mockResolvedValue(puzzle);
+      attemptRepo.save!.mockResolvedValue(savedAttempt);
+
+      const result = await service.submitAttempt(dto);
+
+      expect(result.status).toBe(AttemptStatus.CORRECT);
+      expect(result.score).toBeGreaterThan(0);
+      expect(result.submittedAt).toBeDefined();
+    });
+
+    it('should mark attempt INCORRECT and award 0 score for a wrong answer', async () => {
+      const submitDto = { ...dto, answer: 'wrong' };
+      const attempt = makeAttempt();
+      const puzzle = makePuzzle();
+      const savedAttempt = makeAttempt({
+        status: AttemptStatus.INCORRECT,
+        answer: 'wrong',
+        timeSpent: 30,
+        score: 0,
+        submittedAt: new Date(),
+      });
+
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      puzzleRepo.findOneBy!.mockResolvedValue(puzzle);
+      attemptRepo.save!.mockResolvedValue(savedAttempt);
+
+      const result = await service.submitAttempt(submitDto);
+
+      expect(result.status).toBe(AttemptStatus.INCORRECT);
+      expect(result.score).toBe(0);
+    });
+
+    it('should mark INCORRECT and zero score when solution was already revealed', async () => {
+      const attempt = makeAttempt({ solutionRevealed: true });
+      const puzzle = makePuzzle();
+      const savedAttempt = makeAttempt({
+        status: AttemptStatus.INCORRECT,
+        solutionRevealed: true,
+        score: 0,
+      });
+
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      puzzleRepo.findOneBy!.mockResolvedValue(puzzle);
+      attemptRepo.save!.mockResolvedValue(savedAttempt);
+
+      const result = await service.submitAttempt(dto);
+
+      expect(result.status).toBe(AttemptStatus.INCORRECT);
+      expect(result.score).toBe(0);
+    });
+
+    it('should throw NotFoundException when attempt does not exist', async () => {
+      attemptRepo.findOneBy!.mockResolvedValue(null);
+
+      await expect(service.submitAttempt(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw BadRequestException when attempt is in terminal state', async () => {
+      const attempt = makeAttempt({ status: AttemptStatus.CORRECT });
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+
+      await expect(service.submitAttempt(dto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw NotFoundException when the puzzle no longer exists', async () => {
+      const attempt = makeAttempt();
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      puzzleRepo.findOneBy!.mockResolvedValue(null);
+
+      await expect(service.submitAttempt(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should perform case-insensitive answer comparison', async () => {
+      const dto2 = { ...dto, answer: 'FOUR' };
+      const attempt = makeAttempt();
+      const puzzle = makePuzzle({ correctAnswer: 'four' });
+      const savedAttempt = makeAttempt({
+        status: AttemptStatus.CORRECT,
+        score: 100,
+      });
+
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      puzzleRepo.findOneBy!.mockResolvedValue(puzzle);
+      attemptRepo.save!.mockResolvedValue(savedAttempt);
+
+      const result = await service.submitAttempt(dto2);
+      expect(result.status).toBe(AttemptStatus.CORRECT);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // useHint
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('useHint', () => {
+    const dto: UseHintDto = { attemptId: 'attempt-uuid-1' };
+
+    it('should increment hintsUsed and save the attempt', async () => {
+      const attempt = makeAttempt({ hintsUsed: 0 });
+      const savedAttempt = makeAttempt({ hintsUsed: 1 });
+
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      attemptRepo.save!.mockResolvedValue(savedAttempt);
+
+      const result = await service.useHint(dto);
+      expect(result.hintsUsed).toBe(1);
+      expect(attemptRepo.save).toHaveBeenCalled();
+    });
+
+    it('should accumulate hintsUsed across multiple hint calls', async () => {
+      // Simulate a second hint call (attempt already has hintsUsed=1)
+      const attempt = makeAttempt({ hintsUsed: 1 });
+      const savedAttempt = makeAttempt({ hintsUsed: 2 });
+
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      attemptRepo.save!.mockResolvedValue(savedAttempt);
+
+      const result = await service.useHint(dto);
+      expect(result.hintsUsed).toBe(2);
+    });
+
+    it('should throw NotFoundException when attempt does not exist', async () => {
+      attemptRepo.findOneBy!.mockResolvedValue(null);
+      await expect(service.useHint(dto)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException when attempt is in a terminal state', async () => {
+      const attempt = makeAttempt({ status: AttemptStatus.EXPIRED });
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      await expect(service.useHint(dto)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // revealSolution
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('revealSolution', () => {
+    const dto: RevealSolutionDto = { attemptId: 'attempt-uuid-1' };
+
+    it('should set solutionRevealed=true, status=INCORRECT, score=0 for a STARTED attempt', async () => {
+      const attempt = makeAttempt({ status: AttemptStatus.STARTED });
+      const savedAttempt = makeAttempt({
+        status: AttemptStatus.INCORRECT,
+        solutionRevealed: true,
+        score: 0,
+        submittedAt: new Date(),
+      });
+
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      attemptRepo.save!.mockResolvedValue(savedAttempt);
+
+      const result = await service.revealSolution(dto);
+
+      expect(result.solutionRevealed).toBe(true);
+      expect(result.status).toBe(AttemptStatus.INCORRECT);
+      expect(result.score).toBe(0);
+      expect(result.submittedAt).toBeDefined();
+    });
+
+    it('should set solutionRevealed=true and zero score without changing status when SUBMITTED', async () => {
+      const attempt = makeAttempt({
+        status: AttemptStatus.SUBMITTED,
+        submittedAt: new Date(),
+      });
+      const savedAttempt = makeAttempt({
+        status: AttemptStatus.SUBMITTED,
+        solutionRevealed: true,
+        score: 0,
+      });
+
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      attemptRepo.save!.mockResolvedValue(savedAttempt);
+
+      const result = await service.revealSolution(dto);
+      expect(result.solutionRevealed).toBe(true);
+      expect(result.status).toBe(AttemptStatus.SUBMITTED);
+    });
+
+    it('should throw NotFoundException when attempt does not exist', async () => {
+      attemptRepo.findOneBy!.mockResolvedValue(null);
+      await expect(service.revealSolution(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw BadRequestException when attempt is already CORRECT', async () => {
+      const attempt = makeAttempt({ status: AttemptStatus.CORRECT });
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      await expect(service.revealSolution(dto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException when attempt is already INCORRECT', async () => {
+      const attempt = makeAttempt({ status: AttemptStatus.INCORRECT });
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      await expect(service.revealSolution(dto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException when attempt is already EXPIRED', async () => {
+      const attempt = makeAttempt({ status: AttemptStatus.EXPIRED });
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      await expect(service.revealSolution(dto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // expireAttempt
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('expireAttempt', () => {
+    it('should set status=EXPIRED on a STARTED attempt', async () => {
+      const attempt = makeAttempt({ status: AttemptStatus.STARTED });
+      const savedAttempt = makeAttempt({
+        status: AttemptStatus.EXPIRED,
+        submittedAt: new Date(),
+      });
+
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      attemptRepo.save!.mockResolvedValue(savedAttempt);
+
+      const result = await service.expireAttempt('attempt-uuid-1');
+      expect(result.status).toBe(AttemptStatus.EXPIRED);
+    });
+
+    it('should set status=EXPIRED on a SUBMITTED attempt', async () => {
+      const attempt = makeAttempt({
+        status: AttemptStatus.SUBMITTED,
+        submittedAt: new Date(),
+      });
+      const savedAttempt = makeAttempt({
+        status: AttemptStatus.EXPIRED,
+        submittedAt: new Date(),
+      });
+
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      attemptRepo.save!.mockResolvedValue(savedAttempt);
+
+      const result = await service.expireAttempt('attempt-uuid-1');
+      expect(result.status).toBe(AttemptStatus.EXPIRED);
+    });
+
+    it('should throw NotFoundException when attempt does not exist', async () => {
+      attemptRepo.findOneBy!.mockResolvedValue(null);
+      await expect(service.expireAttempt('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw BadRequestException when attempt is already CORRECT', async () => {
+      const attempt = makeAttempt({ status: AttemptStatus.CORRECT });
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+      await expect(service.expireAttempt('attempt-uuid-1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // findById
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('findById', () => {
+    it('should return the attempt when found', async () => {
+      const attempt = makeAttempt();
+      attemptRepo.findOneBy!.mockResolvedValue(attempt);
+
+      const result = await service.findById('attempt-uuid-1');
+      expect(result).toEqual(attempt);
+      expect(attemptRepo.findOneBy).toHaveBeenCalledWith({
+        id: 'attempt-uuid-1',
+      });
+    });
+
+    it('should throw NotFoundException when attempt is not found', async () => {
+      attemptRepo.findOneBy!.mockResolvedValue(null);
+      await expect(service.findById('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // findByUser
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('findByUser', () => {
+    it('should return all attempts for a user ordered by startedAt DESC', async () => {
+      const attempts = [makeAttempt(), makeAttempt({ id: 'attempt-uuid-2' })];
+      attemptRepo.find!.mockResolvedValue(attempts);
+
+      const result = await service.findByUser('user-uuid-1');
+
+      expect(attemptRepo.find).toHaveBeenCalledWith({
+        where: { userId: 'user-uuid-1' },
+        order: { startedAt: 'DESC' },
+      });
+      expect(result).toHaveLength(2);
+    });
+
+    it('should return an empty array when the user has no attempts', async () => {
+      attemptRepo.find!.mockResolvedValue([]);
+      const result = await service.findByUser('user-uuid-unknown');
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // findBySession
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('findBySession', () => {
+    it('should return all attempts in a session ordered by startedAt ASC', async () => {
+      const attempts = [
+        makeAttempt({ sessionId: 'sess-1' }),
+        makeAttempt({ id: 'attempt-uuid-2', sessionId: 'sess-1' }),
+      ];
+      attemptRepo.find!.mockResolvedValue(attempts);
+
+      const result = await service.findBySession('sess-1');
+
+      expect(attemptRepo.find).toHaveBeenCalledWith({
+        where: { sessionId: 'sess-1' },
+        order: { startedAt: 'ASC' },
+      });
+      expect(result).toHaveLength(2);
+    });
+
+    it('should return an empty array when no attempts exist for the session', async () => {
+      attemptRepo.find!.mockResolvedValue([]);
+      const result = await service.findBySession('unknown-session');
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // validateAnswer (unit tests for the helper directly)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('validateAnswer', () => {
+    it('should return true for an exact match', () => {
+      expect(service.validateAnswer('4', '4')).toBe(true);
+    });
+
+    it('should return true for a case-insensitive match', () => {
+      expect(service.validateAnswer('FOUR', 'four')).toBe(true);
+    });
+
+    it('should return true when both sides differ only in whitespace', () => {
+      expect(service.validateAnswer('  four  ', 'four')).toBe(true);
+    });
+
+    it('should return false for a clearly wrong answer', () => {
+      expect(service.validateAnswer('3', '4')).toBe(false);
+    });
+
+    it('should return false for an empty answer against a non-empty correct answer', () => {
+      expect(service.validateAnswer('', '4')).toBe(false);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // calculateScore (unit tests for the helper directly)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('calculateScore', () => {
+    it('should return base points when timeSpent equals timeLimit (no bonus)', () => {
+      const score = service.calculateScore(100, 60, 60);
+      expect(score).toBe(100); // 100 * (1 + 0) = 100
+    });
+
+    it('should return full bonus (50%) when timeSpent is 0', () => {
+      const score = service.calculateScore(100, 0, 60);
+      expect(score).toBe(150); // 100 * (1 + 0.5) = 150
+    });
+
+    it('should return partial bonus when timeSpent is half of timeLimit', () => {
+      // bonus = (60 - 30) / 60 * 0.5 = 0.25 → total = 100 * 1.25 = 125
+      const score = service.calculateScore(100, 30, 60);
+      expect(score).toBe(125);
+    });
+
+    it('should return base points when timeSpent exceeds timeLimit (no bonus)', () => {
+      const score = service.calculateScore(100, 90, 60);
+      expect(score).toBe(100); // time exceeded, no bonus
+    });
+
+    it('should return 0 when basePoints is 0', () => {
+      const score = service.calculateScore(0, 10, 60);
+      expect(score).toBe(0);
+    });
+  });
+});

--- a/backend/src/challenge-attempt/providers/challenge-attempt.service.ts
+++ b/backend/src/challenge-attempt/providers/challenge-attempt.service.ts
@@ -1,0 +1,275 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ChallengeAttempt } from '../entities/challenge-attempt.entity';
+import { Puzzle } from '../../puzzles/entities/puzzle.entity';
+import { AttemptStatus } from '../enums/attempt-status.enum';
+import { CreateChallengeAttemptDto } from '../dtos/create-challenge-attempt.dto';
+import { SubmitAttemptDto } from '../dtos/submit-attempt.dto';
+import { RevealSolutionDto } from '../dtos/reveal-solution.dto';
+import { UseHintDto } from '../dtos/use-hint.dto';
+
+/** Terminal states where no further mutations are allowed. */
+const TERMINAL_STATES = new Set<AttemptStatus>([
+  AttemptStatus.CORRECT,
+  AttemptStatus.INCORRECT,
+  AttemptStatus.EXPIRED,
+]);
+
+@Injectable()
+export class ChallengeAttemptService {
+  constructor(
+    @InjectRepository(ChallengeAttempt)
+    private readonly attemptRepository: Repository<ChallengeAttempt>,
+    @InjectRepository(Puzzle)
+    private readonly puzzleRepository: Repository<Puzzle>,
+  ) {}
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Attempt Creation
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Starts a new challenge attempt for a user.
+   *
+   * Creates a record in STARTED state. The user can then submit an answer,
+   * use hints, or reveal the solution.
+   */
+  async createAttempt(
+    dto: CreateChallengeAttemptDto,
+  ): Promise<ChallengeAttempt> {
+    const challengeExists = await this.puzzleRepository.existsBy({
+      id: dto.challengeId,
+    });
+    if (!challengeExists) {
+      throw new NotFoundException(
+        `Challenge with ID ${dto.challengeId} not found`,
+      );
+    }
+
+    const attempt = this.attemptRepository.create({
+      userId: dto.userId,
+      challengeId: dto.challengeId,
+      sessionId: dto.sessionId,
+      status: AttemptStatus.STARTED,
+      score: 0,
+      timeSpent: 0,
+      hintsUsed: 0,
+      solutionRevealed: false,
+    });
+
+    return this.attemptRepository.save(attempt);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Answer Submission & Result Recording
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Submits an answer for an existing attempt.
+   *
+   * - Validates the attempt exists and is in a submittable state.
+   * - Compares the answer against the puzzle's correct answer (case-insensitive
+   *   with whitespace trimming).
+   * - Sets status to CORRECT or INCORRECT, records timeSpent and submittedAt.
+   * - Awards score only on correct answers (unless solution was already
+   *   revealed, which forfeits scoring).
+   */
+  async submitAttempt(dto: SubmitAttemptDto): Promise<ChallengeAttempt> {
+    const attempt = await this.findAttemptOrFail(dto.attemptId);
+    this.assertMutable(attempt);
+
+    const puzzle = await this.puzzleRepository.findOneBy({
+      id: attempt.challengeId,
+    });
+    if (!puzzle) {
+      throw new NotFoundException(
+        `Challenge with ID ${attempt.challengeId} not found`,
+      );
+    }
+
+    const isCorrect = this.validateAnswer(dto.answer, puzzle.correctAnswer);
+
+    attempt.answer = dto.answer;
+    attempt.timeSpent = dto.timeSpent;
+    attempt.submittedAt = new Date();
+    attempt.status = AttemptStatus.SUBMITTED;
+
+    // Final grading — solution reveals forfeit any score
+    if (attempt.solutionRevealed) {
+      attempt.status = AttemptStatus.INCORRECT;
+      attempt.score = 0;
+    } else if (isCorrect) {
+      attempt.status = AttemptStatus.CORRECT;
+      attempt.score = this.calculateScore(puzzle.points, dto.timeSpent, puzzle.timeLimit);
+    } else {
+      attempt.status = AttemptStatus.INCORRECT;
+      attempt.score = 0;
+    }
+
+    return this.attemptRepository.save(attempt);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Hint Tracking
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Records that the player used a hint for this attempt.
+   *
+   * Increments hintsUsed. The actual hint content is retrieved from the
+   * puzzle by the caller; this method only tracks the usage count.
+   *
+   * Hints cannot be used after an attempt has reached a terminal state.
+   */
+  async useHint(dto: UseHintDto): Promise<ChallengeAttempt> {
+    const attempt = await this.findAttemptOrFail(dto.attemptId);
+    this.assertMutable(attempt);
+
+    attempt.hintsUsed += 1;
+    return this.attemptRepository.save(attempt);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Solution Reveal Tracking
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Records that the player revealed the solution for this attempt.
+   *
+   * Sets solutionRevealed = true. If the attempt is still STARTED it is
+   * immediately moved to INCORRECT because the player chose not to attempt
+   * it honestly. If the attempt has already been SUBMITTED it keeps its
+   * status unchanged (the status was already set during submission).
+   *
+   * Either way, the score is zeroed out.
+   */
+  async revealSolution(dto: RevealSolutionDto): Promise<ChallengeAttempt> {
+    const attempt = await this.findAttemptOrFail(dto.attemptId);
+
+    if (TERMINAL_STATES.has(attempt.status)) {
+      throw new BadRequestException(
+        `Cannot reveal solution for an attempt that is already ${attempt.status}`,
+      );
+    }
+
+    attempt.solutionRevealed = true;
+    attempt.score = 0;
+
+    if (attempt.status === AttemptStatus.STARTED) {
+      attempt.status = AttemptStatus.INCORRECT;
+      attempt.submittedAt = new Date();
+    }
+
+    return this.attemptRepository.save(attempt);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Expiry
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Marks an attempt as EXPIRED (e.g. when the time limit elapses).
+   *
+   * Can only transition from STARTED or SUBMITTED states.
+   */
+  async expireAttempt(attemptId: string): Promise<ChallengeAttempt> {
+    const attempt = await this.findAttemptOrFail(attemptId);
+    this.assertMutable(attempt);
+
+    attempt.status = AttemptStatus.EXPIRED;
+    attempt.submittedAt = attempt.submittedAt ?? new Date();
+    return this.attemptRepository.save(attempt);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Queries
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Returns a single attempt by ID.
+   */
+  async findById(attemptId: string): Promise<ChallengeAttempt> {
+    return this.findAttemptOrFail(attemptId);
+  }
+
+  /**
+   * Returns all attempts for a given user, ordered newest-first.
+   */
+  async findByUser(userId: string): Promise<ChallengeAttempt[]> {
+    return this.attemptRepository.find({
+      where: { userId },
+      order: { startedAt: 'DESC' },
+    });
+  }
+
+  /**
+   * Returns all attempts belonging to a specific session.
+   */
+  async findBySession(sessionId: string): Promise<ChallengeAttempt[]> {
+    return this.attemptRepository.find({
+      where: { sessionId },
+      order: { startedAt: 'ASC' },
+    });
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Helpers
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Retrieves an attempt by ID and throws NotFoundException if missing.
+   */
+  async findAttemptOrFail(attemptId: string): Promise<ChallengeAttempt> {
+    const attempt = await this.attemptRepository.findOneBy({ id: attemptId });
+    if (!attempt) {
+      throw new NotFoundException(
+        `Attempt with ID ${attemptId} not found`,
+      );
+    }
+    return attempt;
+  }
+
+  /**
+   * Throws BadRequestException if the attempt is in a terminal state.
+   */
+  private assertMutable(attempt: ChallengeAttempt): void {
+    if (TERMINAL_STATES.has(attempt.status)) {
+      throw new BadRequestException(
+        `Attempt ${attempt.id} is already in terminal state ${attempt.status} and cannot be modified`,
+      );
+    }
+  }
+
+  /**
+   * Validates a user's answer against the correct answer.
+   * Case-insensitive, whitespace-trimmed comparison.
+   */
+  validateAnswer(userAnswer: string, correctAnswer: string): boolean {
+    return (
+      userAnswer.trim().toLowerCase() === correctAnswer.trim().toLowerCase()
+    );
+  }
+
+  /**
+   * Calculates score for a correct answer with a time bonus.
+   *
+   * Full base points are awarded; bonus of up to 50% for finishing
+   * faster than the time limit (mirrors ProgressCalculationProvider logic).
+   */
+  calculateScore(
+    basePoints: number,
+    timeSpent: number,
+    timeLimit: number,
+  ): number {
+    let bonus = 0;
+    if (timeSpent < timeLimit) {
+      bonus = ((timeLimit - timeSpent) / timeLimit) * 0.5;
+    }
+    return Math.round(basePoints * (1 + bonus));
+  }
+}


### PR DESCRIPTION
## Summary

Implements the **Challenge Attempt System** as described in issue #612.

Closes #612

---

## What was built

### Domain model
- `AttemptStatus` enum: `STARTED`, `SUBMITTED`, `CORRECT`, `INCORRECT`, `EXPIRED`
- `ChallengeAttempt` entity (`challenge_attempts` table) with all required fields:
  `id` · `sessionId` · `userId` · `challengeId` · `answer` · `status` · `score` · `timeSpent` · `hintsUsed` · `solutionRevealed` · `startedAt` · `submittedAt`

### DTOs (class-validator decorated)
| DTO | Purpose |
|-----|---------|
| `CreateChallengeAttemptDto` | Start a new attempt |
| `SubmitAttemptDto` | Submit an answer with time spent |
| `RevealSolutionDto` | Reveal the solution |
| `UseHintDto` | Record hint usage |

### Service (`ChallengeAttemptService`)
| Operation | Description |
|-----------|-------------|
| `createAttempt` | Creates attempt in `STARTED` state |
| `submitAttempt` | Validates answer (case-insensitive), grades, awards score with time bonus |
| `useHint` | Increments `hintsUsed` counter |
| `revealSolution` | Sets `solutionRevealed=true`, forfeits score |
| `expireAttempt` | Transitions to `EXPIRED` |
| `findById` / `findByUser` / `findBySession` | Query helpers |

The service enforces a strict lifecycle state machine — terminal states (`CORRECT`, `INCORRECT`, `EXPIRED`) block all further mutations.

### Controller (`ChallengeAttemptController`)
8 REST endpoints under `/challenge-attempts` with full Swagger documentation.

### Module
`ChallengeAttemptModule` registered in `AppModule`.

---

## Tests
- **41 unit tests** for `ChallengeAttemptService` — all passing
- **Full test suite: 137 tests across 18 suites — all passing**
- TypeScript build: clean (`tsc -p tsconfig.build.json` exits 0)

---

## Acceptance criteria checklist

- [x] ChallengeAttempt entity exists
- [x] Attempts are associated with sessions (`sessionId`)
- [x] Attempts are associated with challenges (`challengeId` → `Puzzle`)
- [x] Submission results are persisted (`answer`, `status`, `score`)
- [x] Time spent is tracked (`timeSpent`, `submittedAt`)
- [x] Hint usage is tracked (`hintsUsed`)
- [x] Solution reveals are tracked (`solutionRevealed`)
- [x] Unit tests exist (41 tests)