### PR TITLE
feature: Implement Game Sessions backend module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -33,6 +33,7 @@ import { GeolocationMiddleware } from './common/middleware/geolocation.middlewar
 import { HealthModule } from './health/health.module';
 import { AnalyticsModule } from './analytics/analytics.module';
 import { ChallengeAttemptModule } from './challenge-attempt/challenge-attempt.module';
+import { GameSessionsModule } from './game-sessions/game-sessions.module';
 
 // const ENV = process.env.NODE_ENV;
 // console.log('NODE_ENV:', process.env.NODE_ENV);
@@ -121,6 +122,7 @@ import { ChallengeAttemptModule } from './challenge-attempt/challenge-attempt.mo
     }),
     HealthModule,
     ChallengeAttemptModule,
+    GameSessionsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/game-sessions/controllers/game-sessions.controller.ts
+++ b/backend/src/game-sessions/controllers/game-sessions.controller.ts
@@ -1,0 +1,168 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { GameSessionsService } from '../providers/game-sessions.service';
+import { CreateGameSessionDto } from '../dtos/create-game-session.dto';
+import { UpdateGameSessionStatusDto } from '../dtos/update-game-session-status.dto';
+import { GameSessionResponseDto } from '../dtos/game-session-response.dto';
+import { GameSession } from '../entities/game-session.entity';
+import { ActiveUser } from '../../auth/decorators/activeUser.decorator';
+import { ActiveUserData } from '../../auth/interfaces/activeInterface';
+
+@ApiTags('game-sessions')
+@Controller('game-sessions')
+export class GameSessionsController {
+  constructor(private readonly gameSessionsService: GameSessionsService) {}
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // POST /game-sessions
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Create a new game session',
+    description:
+      'Creates a game session in CREATED state for the authenticated user (or a guest). ' +
+      'Call PATCH /game-sessions/:id/status with status=ACTIVE to start it.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Game session created successfully',
+    type: GameSessionResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Validation failed' })
+  async create(
+    @Body() dto: CreateGameSessionDto,
+    @ActiveUser() activeUser: ActiveUserData | undefined,
+  ): Promise<GameSession> {
+    const userId = activeUser?.sub ?? null;
+    return this.gameSessionsService.create(dto, userId);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // GET /game-sessions  →  list all sessions for the current user
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'List all game sessions for the authenticated user',
+    description: 'Returns sessions ordered by creation date, most recent first.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Sessions retrieved successfully',
+    type: [GameSessionResponseDto],
+  })
+  async findAll(
+    @ActiveUser() activeUser: ActiveUserData,
+  ): Promise<GameSession[]> {
+    return this.gameSessionsService.findAllByUser(activeUser.sub);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // GET /game-sessions/active
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  @Get('active')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get the currently active session for the authenticated user',
+    description: 'Returns the single ACTIVE session, or null if none exists.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Active session (or null)',
+    type: GameSessionResponseDto,
+  })
+  async findActive(
+    @ActiveUser() activeUser: ActiveUserData,
+  ): Promise<GameSession | null> {
+    return this.gameSessionsService.findActiveSession(activeUser.sub);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // GET /game-sessions/:id
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get a game session by ID' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  @ApiQuery({
+    name: 'guestId',
+    required: false,
+    description: 'Guest identifier (for unauthenticated sessions)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Session found',
+    type: GameSessionResponseDto,
+  })
+  @ApiResponse({ status: 403, description: 'Forbidden – not session owner' })
+  @ApiResponse({ status: 404, description: 'Session not found' })
+  async findOne(
+    @Param('id', ParseUUIDPipe) id: string,
+    @ActiveUser() activeUser: ActiveUserData | undefined,
+    @Query('guestId') guestId?: string,
+  ): Promise<GameSession> {
+    const userId = activeUser?.sub ?? null;
+    return this.gameSessionsService.findAndVerifyOwnership(id, userId, guestId);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // PATCH /game-sessions/:id/status
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  @Patch(':id/status')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Update the status of a game session',
+    description:
+      'Validates the requested status transition according to the state machine ' +
+      'and applies it. Invalid transitions return HTTP 400.',
+  })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  @ApiQuery({
+    name: 'guestId',
+    required: false,
+    description: 'Guest identifier (for unauthenticated sessions)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Status updated successfully',
+    type: GameSessionResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid status transition or validation error',
+  })
+  @ApiResponse({ status: 403, description: 'Forbidden – not session owner' })
+  @ApiResponse({ status: 404, description: 'Session not found' })
+  async updateStatus(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateGameSessionStatusDto,
+    @ActiveUser() activeUser: ActiveUserData | undefined,
+    @Query('guestId') guestId?: string,
+  ): Promise<GameSession> {
+    const userId = activeUser?.sub ?? null;
+    return this.gameSessionsService.updateStatus(id, dto, userId, guestId);
+  }
+}

--- a/backend/src/game-sessions/dtos/create-game-session.dto.ts
+++ b/backend/src/game-sessions/dtos/create-game-session.dto.ts
@@ -1,0 +1,55 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+import { PuzzleDifficulty } from '../../puzzles/enums/puzzle-difficulty.enum';
+
+export class CreateGameSessionDto {
+  /**
+   * Optional guest identifier for unauthenticated sessions.
+   * If not provided the session will be tied to the authenticated user.
+   */
+  @ApiPropertyOptional({
+    description: 'Guest ID for unauthenticated sessions',
+    example: 'guest-abc123',
+  })
+  @IsOptional()
+  @IsString()
+  guestId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Difficulty level for the session',
+    enum: PuzzleDifficulty,
+    example: PuzzleDifficulty.INTERMEDIATE,
+  })
+  @IsOptional()
+  @IsEnum(PuzzleDifficulty)
+  difficulty?: PuzzleDifficulty;
+
+  @ApiPropertyOptional({
+    description: 'Category IDs or slugs to include in this session',
+    example: ['coding', 'logic'],
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  selectedCategories?: string[];
+
+  @ApiProperty({
+    description: 'Number of challenges to include in the session',
+    example: 10,
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  challengeCount: number;
+}

--- a/backend/src/game-sessions/dtos/game-session-response.dto.ts
+++ b/backend/src/game-sessions/dtos/game-session-response.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { GameSessionStatus } from '../enums/game-session-status.enum';
+import { PuzzleDifficulty } from '../../puzzles/enums/puzzle-difficulty.enum';
+
+export class GameSessionResponseDto {
+  @ApiProperty({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' })
+  id: string;
+
+  @ApiPropertyOptional({ example: 'user-uuid', nullable: true })
+  userId: string | null;
+
+  @ApiPropertyOptional({ example: 'guest-abc123', nullable: true })
+  guestId: string | null;
+
+  @ApiProperty({ enum: GameSessionStatus, example: GameSessionStatus.ACTIVE })
+  status: GameSessionStatus;
+
+  @ApiPropertyOptional({ enum: PuzzleDifficulty, nullable: true })
+  difficulty: PuzzleDifficulty | null;
+
+  @ApiPropertyOptional({
+    type: [String],
+    example: ['coding', 'logic'],
+    nullable: true,
+  })
+  selectedCategories: string[] | null;
+
+  @ApiProperty({ example: 10 })
+  challengeCount: number;
+
+  @ApiProperty({ example: 2 })
+  currentChallenge: number;
+
+  @ApiProperty({ example: 300 })
+  score: number;
+
+  @ApiProperty({ example: 50 })
+  xpEarned: number;
+
+  @ApiPropertyOptional({ example: '2026-08-19T12:00:00.000Z', nullable: true })
+  startedAt: Date | null;
+
+  @ApiPropertyOptional({ example: '2026-08-19T12:15:00.000Z', nullable: true })
+  completedAt: Date | null;
+
+  @ApiProperty({ example: '2026-08-19T11:59:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: '2026-08-19T12:00:00.000Z' })
+  updatedAt: Date;
+}

--- a/backend/src/game-sessions/dtos/update-game-session-status.dto.ts
+++ b/backend/src/game-sessions/dtos/update-game-session-status.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsInt, IsOptional, Min } from 'class-validator';
+import { GameSessionStatus } from '../enums/game-session-status.enum';
+
+export class UpdateGameSessionStatusDto {
+  @ApiProperty({
+    description: 'The target status for this session',
+    enum: GameSessionStatus,
+    example: GameSessionStatus.ACTIVE,
+  })
+  @IsEnum(GameSessionStatus)
+  status: GameSessionStatus;
+
+  /**
+   * When completing a session, optionally supply the final score and XP.
+   * The service will ignore these values for non-terminal transitions.
+   */
+  @ApiPropertyOptional({
+    description: 'Final score (used when transitioning to COMPLETED)',
+    example: 850,
+    minimum: 0,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  score?: number;
+
+  @ApiPropertyOptional({
+    description: 'XP earned (used when transitioning to COMPLETED)',
+    example: 120,
+    minimum: 0,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  xpEarned?: number;
+}

--- a/backend/src/game-sessions/entities/game-session.entity.ts
+++ b/backend/src/game-sessions/entities/game-session.entity.ts
@@ -1,0 +1,103 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { GameSessionStatus } from '../enums/game-session-status.enum';
+import { PuzzleDifficulty } from '../../puzzles/enums/puzzle-difficulty.enum';
+import { User } from '../../users/user.entity';
+
+/**
+ * GameSession represents a complete gameplay session for a user.
+ *
+ * A session groups a set of challenges together under a single context
+ * (e.g. a training session, a timed run, or a themed quiz).
+ *
+ * Lifecycle:
+ *   CREATED → ACTIVE → PAUSED → ACTIVE → COMPLETED
+ *                              → EXPIRED
+ *                              → ABANDONED
+ */
+@Entity('game_sessions')
+@Index(['userId', 'status'])
+@Index(['userId', 'startedAt'])
+@Index(['status'])
+export class GameSession {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /**
+   * The authenticated user who owns this session.
+   * Null for guest sessions (guestId is set instead).
+   */
+  @Column({ type: 'uuid', nullable: true })
+  userId: string | null;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE', eager: false, nullable: true })
+  @JoinColumn({ name: 'userId' })
+  user: User | null;
+
+  /**
+   * Optional guest identifier for unauthenticated sessions.
+   */
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  guestId: string | null;
+
+  /** Current lifecycle state of the session. */
+  @Column({
+    type: 'enum',
+    enum: GameSessionStatus,
+    default: GameSessionStatus.CREATED,
+  })
+  status: GameSessionStatus;
+
+  /** Difficulty level chosen for this session. */
+  @Column({
+    type: 'enum',
+    enum: PuzzleDifficulty,
+    nullable: true,
+  })
+  difficulty: PuzzleDifficulty | null;
+
+  /**
+   * Category slugs / IDs the user selected for this session.
+   * Stored as a simple comma-separated list for portability.
+   */
+  @Column({ type: 'simple-array', nullable: true })
+  selectedCategories: string[] | null;
+
+  /** Total number of challenges in this session. */
+  @Column({ type: 'int', default: 0 })
+  challengeCount: number;
+
+  /** Zero-based index of the challenge currently being presented. */
+  @Column({ type: 'int', default: 0 })
+  currentChallenge: number;
+
+  /** Accumulated score across all challenges in this session. */
+  @Column({ type: 'int', default: 0 })
+  score: number;
+
+  /** XP earned by the user for completing this session. */
+  @Column({ type: 'int', default: 0 })
+  xpEarned: number;
+
+  /** Timestamp when the session transitioned from CREATED to ACTIVE. */
+  @Column({ name: 'started_at', type: 'timestamptz', nullable: true })
+  startedAt: Date | null;
+
+  /** Timestamp when the session reached a terminal state (COMPLETED / EXPIRED / ABANDONED). */
+  @Column({ name: 'completed_at', type: 'timestamptz', nullable: true })
+  completedAt: Date | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/backend/src/game-sessions/enums/game-session-status.enum.ts
+++ b/backend/src/game-sessions/enums/game-session-status.enum.ts
@@ -1,0 +1,19 @@
+/**
+ * Lifecycle states for a GameSession.
+ *
+ * Valid transitions:
+ *   CREATED  → ACTIVE
+ *   ACTIVE   → PAUSED | COMPLETED | ABANDONED | EXPIRED
+ *   PAUSED   → ACTIVE | ABANDONED | EXPIRED
+ *   COMPLETED → (terminal)
+ *   EXPIRED   → (terminal)
+ *   ABANDONED → (terminal)
+ */
+export enum GameSessionStatus {
+  CREATED = 'CREATED',
+  ACTIVE = 'ACTIVE',
+  PAUSED = 'PAUSED',
+  COMPLETED = 'COMPLETED',
+  EXPIRED = 'EXPIRED',
+  ABANDONED = 'ABANDONED',
+}

--- a/backend/src/game-sessions/game-sessions.module.ts
+++ b/backend/src/game-sessions/game-sessions.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { GameSession } from './entities/game-session.entity';
+import { GameSessionsService } from './providers/game-sessions.service';
+import { GameSessionsController } from './controllers/game-sessions.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([GameSession])],
+  controllers: [GameSessionsController],
+  providers: [GameSessionsService],
+  exports: [GameSessionsService],
+})
+export class GameSessionsModule {}

--- a/backend/src/game-sessions/interfaces/game-session.interface.ts
+++ b/backend/src/game-sessions/interfaces/game-session.interface.ts
@@ -1,0 +1,45 @@
+import { GameSessionStatus } from '../enums/game-session-status.enum';
+import { PuzzleDifficulty } from '../../puzzles/enums/puzzle-difficulty.enum';
+
+/**
+ * Describes the state machine transition graph.
+ * Key = current status, Value = set of valid next statuses.
+ */
+export type SessionTransitionMap = Readonly<
+  Record<GameSessionStatus, ReadonlyArray<GameSessionStatus>>
+>;
+
+/**
+ * Payload used internally when requesting a status transition.
+ */
+export interface ISessionTransitionRequest {
+  /** The desired next status. */
+  targetStatus: GameSessionStatus;
+  /** Final score – only relevant when moving to COMPLETED. */
+  score?: number;
+  /** XP earned – only relevant when moving to COMPLETED. */
+  xpEarned?: number;
+}
+
+/**
+ * The resolved owner for a session.
+ * Exactly one of userId or guestId must be non-null.
+ */
+export interface ISessionOwner {
+  userId: string | null;
+  guestId: string | null;
+}
+
+/**
+ * Lightweight session summary returned in list endpoints.
+ */
+export interface IGameSessionSummary {
+  id: string;
+  status: GameSessionStatus;
+  difficulty: PuzzleDifficulty | null;
+  score: number;
+  challengeCount: number;
+  currentChallenge: number;
+  startedAt: Date | null;
+  completedAt: Date | null;
+}

--- a/backend/src/game-sessions/providers/game-sessions.service.spec.ts
+++ b/backend/src/game-sessions/providers/game-sessions.service.spec.ts
@@ -1,0 +1,495 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import {
+  GameSessionsService,
+  SESSION_TRANSITIONS,
+} from './game-sessions.service';
+import { GameSession } from '../entities/game-session.entity';
+import { GameSessionStatus } from '../enums/game-session-status.enum';
+import { PuzzleDifficulty } from '../../puzzles/enums/puzzle-difficulty.enum';
+import { CreateGameSessionDto } from '../dtos/create-game-session.dto';
+import { UpdateGameSessionStatusDto } from '../dtos/update-game-session-status.dto';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeSession(overrides: Partial<GameSession> = {}): GameSession {
+  return {
+    id: 'session-uuid-1',
+    userId: 'user-uuid-1',
+    guestId: null,
+    user: null as any,
+    status: GameSessionStatus.CREATED,
+    difficulty: PuzzleDifficulty.BEGINNER,
+    selectedCategories: ['coding'],
+    challengeCount: 5,
+    currentChallenge: 0,
+    score: 0,
+    xpEarned: 0,
+    startedAt: null,
+    completedAt: null,
+    createdAt: new Date('2026-08-01T10:00:00Z'),
+    updatedAt: new Date('2026-08-01T10:00:00Z'),
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suite
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GameSessionsService', () => {
+  let service: GameSessionsService;
+  let repo: jest.Mocked<Repository<GameSession>>;
+
+  beforeEach(async () => {
+    const mockRepo: Partial<jest.Mocked<Repository<GameSession>>> = {
+      create: jest.fn(),
+      save: jest.fn(),
+      find: jest.fn(),
+      findOneBy: jest.fn(),
+      createQueryBuilder: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GameSessionsService,
+        {
+          provide: getRepositoryToken(GameSession),
+          useValue: mockRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get<GameSessionsService>(GameSessionsService);
+    repo = module.get(getRepositoryToken(GameSession));
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // SESSION_TRANSITIONS export
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('SESSION_TRANSITIONS', () => {
+    it('allows CREATED → ACTIVE only', () => {
+      expect(SESSION_TRANSITIONS[GameSessionStatus.CREATED]).toEqual([
+        GameSessionStatus.ACTIVE,
+      ]);
+    });
+
+    it('allows ACTIVE → PAUSED, COMPLETED, ABANDONED, EXPIRED', () => {
+      expect(SESSION_TRANSITIONS[GameSessionStatus.ACTIVE]).toContain(
+        GameSessionStatus.PAUSED,
+      );
+      expect(SESSION_TRANSITIONS[GameSessionStatus.ACTIVE]).toContain(
+        GameSessionStatus.COMPLETED,
+      );
+      expect(SESSION_TRANSITIONS[GameSessionStatus.ACTIVE]).toContain(
+        GameSessionStatus.ABANDONED,
+      );
+      expect(SESSION_TRANSITIONS[GameSessionStatus.ACTIVE]).toContain(
+        GameSessionStatus.EXPIRED,
+      );
+    });
+
+    it('allows PAUSED → ACTIVE, ABANDONED, EXPIRED', () => {
+      expect(SESSION_TRANSITIONS[GameSessionStatus.PAUSED]).toContain(
+        GameSessionStatus.ACTIVE,
+      );
+      expect(SESSION_TRANSITIONS[GameSessionStatus.PAUSED]).toContain(
+        GameSessionStatus.ABANDONED,
+      );
+      expect(SESSION_TRANSITIONS[GameSessionStatus.PAUSED]).toContain(
+        GameSessionStatus.EXPIRED,
+      );
+    });
+
+    it('has no transitions from COMPLETED, EXPIRED, ABANDONED', () => {
+      expect(SESSION_TRANSITIONS[GameSessionStatus.COMPLETED]).toHaveLength(0);
+      expect(SESSION_TRANSITIONS[GameSessionStatus.EXPIRED]).toHaveLength(0);
+      expect(SESSION_TRANSITIONS[GameSessionStatus.ABANDONED]).toHaveLength(0);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // create()
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('create()', () => {
+    const dto: CreateGameSessionDto = {
+      challengeCount: 5,
+      difficulty: PuzzleDifficulty.INTERMEDIATE,
+      selectedCategories: ['logic'],
+    };
+    const userId = 'user-uuid-1';
+
+    it('creates and saves a new session for an authenticated user', async () => {
+      const built = makeSession({ status: GameSessionStatus.CREATED });
+      repo.create.mockReturnValue(built);
+      repo.save.mockResolvedValue(built);
+
+      const result = await service.create(dto, userId);
+
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId,
+          status: GameSessionStatus.CREATED,
+          challengeCount: 5,
+        }),
+      );
+      expect(repo.save).toHaveBeenCalledWith(built);
+      expect(result).toBe(built);
+    });
+
+    it('creates a guest session when userId is null and guestId is supplied', async () => {
+      const guestDto = { ...dto, guestId: 'guest-abc' };
+      const built = makeSession({ userId: null, guestId: 'guest-abc' });
+      repo.create.mockReturnValue(built);
+      repo.save.mockResolvedValue(built);
+
+      const result = await service.create(guestDto, null);
+
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: null, guestId: 'guest-abc' }),
+      );
+      expect(result.guestId).toBe('guest-abc');
+    });
+
+    it('throws BadRequestException when neither userId nor guestId is provided', async () => {
+      await expect(service.create(dto, null)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // findAllByUser()
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('findAllByUser()', () => {
+    it('returns all sessions for the user ordered by createdAt DESC', async () => {
+      const sessions = [makeSession(), makeSession({ id: 'session-uuid-2' })];
+      repo.find.mockResolvedValue(sessions);
+
+      const result = await service.findAllByUser('user-uuid-1');
+
+      expect(repo.find).toHaveBeenCalledWith({
+        where: { userId: 'user-uuid-1' },
+        order: { createdAt: 'DESC' },
+      });
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // findActiveSession()
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('findActiveSession()', () => {
+    it('returns the active session if one exists', async () => {
+      const active = makeSession({ status: GameSessionStatus.ACTIVE });
+      repo.findOneBy.mockResolvedValue(active);
+
+      const result = await service.findActiveSession('user-uuid-1');
+
+      expect(repo.findOneBy).toHaveBeenCalledWith({
+        userId: 'user-uuid-1',
+        status: GameSessionStatus.ACTIVE,
+      });
+      expect(result?.status).toBe(GameSessionStatus.ACTIVE);
+    });
+
+    it('returns null if no active session exists', async () => {
+      repo.findOneBy.mockResolvedValue(null);
+      const result = await service.findActiveSession('user-uuid-1');
+      expect(result).toBeNull();
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // findById()
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('findById()', () => {
+    it('returns the session when found', async () => {
+      const session = makeSession();
+      repo.findOneBy.mockResolvedValue(session);
+
+      const result = await service.findById('session-uuid-1');
+
+      expect(result).toBe(session);
+    });
+
+    it('throws NotFoundException when session does not exist', async () => {
+      repo.findOneBy.mockResolvedValue(null);
+      await expect(service.findById('bad-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // findAndVerifyOwnership()
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('findAndVerifyOwnership()', () => {
+    it('returns the session when the user is the owner', async () => {
+      const session = makeSession({ userId: 'user-uuid-1' });
+      repo.findOneBy.mockResolvedValue(session);
+
+      const result = await service.findAndVerifyOwnership(
+        'session-uuid-1',
+        'user-uuid-1',
+      );
+      expect(result).toBe(session);
+    });
+
+    it('returns the session when the guest is the owner', async () => {
+      const session = makeSession({ userId: null, guestId: 'guest-abc' });
+      repo.findOneBy.mockResolvedValue(session);
+
+      const result = await service.findAndVerifyOwnership(
+        'session-uuid-1',
+        null,
+        'guest-abc',
+      );
+      expect(result).toBe(session);
+    });
+
+    it('throws ForbiddenException when the user does not own the session', async () => {
+      const session = makeSession({ userId: 'user-uuid-1' });
+      repo.findOneBy.mockResolvedValue(session);
+
+      await expect(
+        service.findAndVerifyOwnership('session-uuid-1', 'different-user'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws ForbiddenException when neither userId nor guestId matches', async () => {
+      const session = makeSession({ userId: 'user-uuid-1', guestId: null });
+      repo.findOneBy.mockResolvedValue(session);
+
+      await expect(
+        service.findAndVerifyOwnership('session-uuid-1', null, 'wrong-guest'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // updateStatus()
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('updateStatus()', () => {
+    const userId = 'user-uuid-1';
+
+    it('transitions CREATED → ACTIVE and stamps startedAt', async () => {
+      const session = makeSession({ status: GameSessionStatus.CREATED });
+      repo.findOneBy.mockResolvedValue(session);
+      repo.save.mockImplementation(async (s) => s as GameSession);
+
+      const dto: UpdateGameSessionStatusDto = {
+        status: GameSessionStatus.ACTIVE,
+      };
+      const result = await service.updateStatus(
+        'session-uuid-1',
+        dto,
+        userId,
+      );
+
+      expect(result.status).toBe(GameSessionStatus.ACTIVE);
+      expect(result.startedAt).toBeInstanceOf(Date);
+      expect(result.completedAt).toBeNull();
+    });
+
+    it('transitions ACTIVE → PAUSED', async () => {
+      const session = makeSession({
+        status: GameSessionStatus.ACTIVE,
+        startedAt: new Date(),
+      });
+      repo.findOneBy.mockResolvedValue(session);
+      repo.save.mockImplementation(async (s) => s as GameSession);
+
+      const dto: UpdateGameSessionStatusDto = {
+        status: GameSessionStatus.PAUSED,
+      };
+      const result = await service.updateStatus(
+        'session-uuid-1',
+        dto,
+        userId,
+      );
+
+      expect(result.status).toBe(GameSessionStatus.PAUSED);
+    });
+
+    it('transitions ACTIVE → COMPLETED, stamps completedAt and persists score/xp', async () => {
+      const session = makeSession({
+        status: GameSessionStatus.ACTIVE,
+        startedAt: new Date(),
+      });
+      repo.findOneBy.mockResolvedValue(session);
+      repo.save.mockImplementation(async (s) => s as GameSession);
+
+      const dto: UpdateGameSessionStatusDto = {
+        status: GameSessionStatus.COMPLETED,
+        score: 900,
+        xpEarned: 200,
+      };
+      const result = await service.updateStatus(
+        'session-uuid-1',
+        dto,
+        userId,
+      );
+
+      expect(result.status).toBe(GameSessionStatus.COMPLETED);
+      expect(result.score).toBe(900);
+      expect(result.xpEarned).toBe(200);
+      expect(result.completedAt).toBeInstanceOf(Date);
+    });
+
+    it('transitions ACTIVE → ABANDONED and stamps completedAt', async () => {
+      const session = makeSession({
+        status: GameSessionStatus.ACTIVE,
+        startedAt: new Date(),
+      });
+      repo.findOneBy.mockResolvedValue(session);
+      repo.save.mockImplementation(async (s) => s as GameSession);
+
+      const dto: UpdateGameSessionStatusDto = {
+        status: GameSessionStatus.ABANDONED,
+      };
+      const result = await service.updateStatus(
+        'session-uuid-1',
+        dto,
+        userId,
+      );
+
+      expect(result.status).toBe(GameSessionStatus.ABANDONED);
+      expect(result.completedAt).toBeInstanceOf(Date);
+    });
+
+    it('throws BadRequestException for an invalid transition (CREATED → COMPLETED)', async () => {
+      const session = makeSession({ status: GameSessionStatus.CREATED });
+      repo.findOneBy.mockResolvedValue(session);
+
+      const dto: UpdateGameSessionStatusDto = {
+        status: GameSessionStatus.COMPLETED,
+      };
+      await expect(
+        service.updateStatus('session-uuid-1', dto, userId),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when session is in a terminal state', async () => {
+      const session = makeSession({ status: GameSessionStatus.COMPLETED });
+      repo.findOneBy.mockResolvedValue(session);
+
+      const dto: UpdateGameSessionStatusDto = {
+        status: GameSessionStatus.ACTIVE,
+      };
+      await expect(
+        service.updateStatus('session-uuid-1', dto, userId),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('does not stamp startedAt again when re-activating a paused session', async () => {
+      const originalStartedAt = new Date('2026-01-01T09:00:00Z');
+      const session = makeSession({
+        status: GameSessionStatus.PAUSED,
+        startedAt: originalStartedAt,
+      });
+      repo.findOneBy.mockResolvedValue(session);
+      repo.save.mockImplementation(async (s) => s as GameSession);
+
+      const dto: UpdateGameSessionStatusDto = {
+        status: GameSessionStatus.ACTIVE,
+      };
+      const result = await service.updateStatus(
+        'session-uuid-1',
+        dto,
+        userId,
+      );
+
+      expect(result.startedAt).toBe(originalStartedAt);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // completeSession()
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('completeSession()', () => {
+    it('delegates to updateStatus with COMPLETED status and supplied score/xp', async () => {
+      const session = makeSession({
+        status: GameSessionStatus.ACTIVE,
+        startedAt: new Date(),
+      });
+      repo.findOneBy.mockResolvedValue(session);
+      repo.save.mockImplementation(async (s) => s as GameSession);
+
+      const result = await service.completeSession(
+        'session-uuid-1',
+        500,
+        80,
+        'user-uuid-1',
+      );
+
+      expect(result.status).toBe(GameSessionStatus.COMPLETED);
+      expect(result.score).toBe(500);
+      expect(result.xpEarned).toBe(80);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // expireIdleSessions()
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('expireIdleSessions()', () => {
+    it('expires stale ACTIVE / PAUSED sessions and returns count', async () => {
+      const staleSessions = [
+        makeSession({ status: GameSessionStatus.ACTIVE }),
+        makeSession({
+          id: 'session-uuid-2',
+          status: GameSessionStatus.PAUSED,
+        }),
+      ];
+
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(staleSessions),
+      } as unknown as SelectQueryBuilder<GameSession>;
+
+      repo.createQueryBuilder.mockReturnValue(qb);
+      repo.save.mockImplementation(async (s) => s as unknown as GameSession);
+
+      const count = await service.expireIdleSessions(30);
+
+      expect(count).toBe(2);
+      expect(staleSessions[0].status).toBe(GameSessionStatus.EXPIRED);
+      expect(staleSessions[1].status).toBe(GameSessionStatus.EXPIRED);
+      expect(staleSessions[0].completedAt).toBeInstanceOf(Date);
+    });
+
+    it('returns 0 when no stale sessions are found', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      } as unknown as SelectQueryBuilder<GameSession>;
+
+      repo.createQueryBuilder.mockReturnValue(qb);
+
+      const count = await service.expireIdleSessions(30);
+      expect(count).toBe(0);
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/game-sessions/providers/game-sessions.service.ts
+++ b/backend/src/game-sessions/providers/game-sessions.service.ts
@@ -1,0 +1,292 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { GameSession } from '../entities/game-session.entity';
+import { GameSessionStatus } from '../enums/game-session-status.enum';
+import { CreateGameSessionDto } from '../dtos/create-game-session.dto';
+import { UpdateGameSessionStatusDto } from '../dtos/update-game-session-status.dto';
+import { SessionTransitionMap } from '../interfaces/game-session.interface';
+
+/**
+ * Valid state transitions for a GameSession.
+ *
+ * CREATED  → ACTIVE
+ * ACTIVE   → PAUSED | COMPLETED | ABANDONED | EXPIRED
+ * PAUSED   → ACTIVE | ABANDONED | EXPIRED
+ * COMPLETED, EXPIRED, ABANDONED are terminal – no further transitions allowed.
+ */
+export const SESSION_TRANSITIONS: SessionTransitionMap = {
+  [GameSessionStatus.CREATED]: [GameSessionStatus.ACTIVE],
+  [GameSessionStatus.ACTIVE]: [
+    GameSessionStatus.PAUSED,
+    GameSessionStatus.COMPLETED,
+    GameSessionStatus.ABANDONED,
+    GameSessionStatus.EXPIRED,
+  ],
+  [GameSessionStatus.PAUSED]: [
+    GameSessionStatus.ACTIVE,
+    GameSessionStatus.ABANDONED,
+    GameSessionStatus.EXPIRED,
+  ],
+  [GameSessionStatus.COMPLETED]: [],
+  [GameSessionStatus.EXPIRED]: [],
+  [GameSessionStatus.ABANDONED]: [],
+};
+
+/** Terminal states – no mutations are allowed once reached. */
+const TERMINAL_STATES = new Set<GameSessionStatus>([
+  GameSessionStatus.COMPLETED,
+  GameSessionStatus.EXPIRED,
+  GameSessionStatus.ABANDONED,
+]);
+
+@Injectable()
+export class GameSessionsService {
+  constructor(
+    @InjectRepository(GameSession)
+    private readonly sessionRepository: Repository<GameSession>,
+  ) {}
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Session Creation
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Creates a new game session in CREATED state.
+   *
+   * @param dto      Creation parameters (difficulty, categories, challenge count, …)
+   * @param userId   Authenticated user ID, or null for guest sessions.
+   */
+  async create(
+    dto: CreateGameSessionDto,
+    userId: string | null,
+  ): Promise<GameSession> {
+    if (!userId && !dto.guestId) {
+      throw new BadRequestException(
+        'Either an authenticated user or a guestId is required to create a session.',
+      );
+    }
+
+    const session = this.sessionRepository.create({
+      userId: userId ?? null,
+      guestId: dto.guestId ?? null,
+      status: GameSessionStatus.CREATED,
+      difficulty: dto.difficulty ?? null,
+      selectedCategories: dto.selectedCategories ?? null,
+      challengeCount: dto.challengeCount,
+      currentChallenge: 0,
+      score: 0,
+      xpEarned: 0,
+      startedAt: null,
+      completedAt: null,
+    });
+
+    return this.sessionRepository.save(session);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Session Retrieval
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Returns all sessions belonging to a user, ordered by most recent first.
+   */
+  async findAllByUser(userId: string): Promise<GameSession[]> {
+    return this.sessionRepository.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  /**
+   * Returns the single active session for a user (if any).
+   * A user may have only one ACTIVE session at a time.
+   */
+  async findActiveSession(userId: string): Promise<GameSession | null> {
+    return this.sessionRepository.findOneBy({
+      userId,
+      status: GameSessionStatus.ACTIVE,
+    });
+  }
+
+  /**
+   * Returns a session by its ID. Throws 404 if not found.
+   */
+  async findById(id: string): Promise<GameSession> {
+    const session = await this.sessionRepository.findOneBy({ id });
+    if (!session) {
+      throw new NotFoundException(`Game session with ID "${id}" not found.`);
+    }
+    return session;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Ownership Enforcement
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Returns a session after verifying the requesting user owns it.
+   *
+   * @param id     Session ID
+   * @param userId The authenticated user's ID (or null for guest checks via guestId).
+   * @param guestId Optional guest identifier.
+   */
+  async findAndVerifyOwnership(
+    id: string,
+    userId: string | null,
+    guestId?: string,
+  ): Promise<GameSession> {
+    const session = await this.findById(id);
+
+    const isOwner =
+      (userId && session.userId === userId) ||
+      (guestId && session.guestId === guestId);
+
+    if (!isOwner) {
+      throw new ForbiddenException(
+        'You do not have permission to access this game session.',
+      );
+    }
+
+    return session;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Status / State Machine
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Transitions a session to the requested status.
+   *
+   * Rules:
+   * - The caller must own the session.
+   * - The transition must be valid according to SESSION_TRANSITIONS.
+   * - Score and xpEarned are only persisted when moving to COMPLETED.
+   * - startedAt is stamped when moving to ACTIVE (for the first time).
+   * - completedAt is stamped when reaching a terminal state.
+   *
+   * @param id     Session ID
+   * @param dto    Target status + optional completion payload
+   * @param userId Requesting user's ID (null for guest)
+   * @param guestId Guest identifier (if applicable)
+   */
+  async updateStatus(
+    id: string,
+    dto: UpdateGameSessionStatusDto,
+    userId: string | null,
+    guestId?: string,
+  ): Promise<GameSession> {
+    const session = await this.findAndVerifyOwnership(id, userId, guestId);
+
+    this.assertValidTransition(session.status, dto.status);
+
+    // Apply state-specific side-effects
+    if (
+      dto.status === GameSessionStatus.ACTIVE &&
+      session.startedAt === null
+    ) {
+      session.startedAt = new Date();
+    }
+
+    if (TERMINAL_STATES.has(dto.status)) {
+      session.completedAt = new Date();
+    }
+
+    if (dto.status === GameSessionStatus.COMPLETED) {
+      if (dto.score !== undefined) session.score = dto.score;
+      if (dto.xpEarned !== undefined) session.xpEarned = dto.xpEarned;
+    }
+
+    session.status = dto.status;
+
+    return this.sessionRepository.save(session);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Session Completion
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Convenience method to mark a session as COMPLETED with a final score/XP.
+   */
+  async completeSession(
+    id: string,
+    score: number,
+    xpEarned: number,
+    userId: string | null,
+  ): Promise<GameSession> {
+    return this.updateStatus(
+      id,
+      { status: GameSessionStatus.COMPLETED, score, xpEarned },
+      userId,
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Session Expiration
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Marks all sessions that are in ACTIVE or PAUSED state and were last updated
+   * more than `maxIdleMinutes` minutes ago as EXPIRED.
+   *
+   * This method is intended to be called by a scheduled job.
+   *
+   * @param maxIdleMinutes  Number of minutes of inactivity after which a session expires.
+   * @returns Number of sessions that were expired.
+   */
+  async expireIdleSessions(maxIdleMinutes = 30): Promise<number> {
+    const cutoff = new Date(Date.now() - maxIdleMinutes * 60 * 1_000);
+
+    const staleSessions = await this.sessionRepository
+      .createQueryBuilder('session')
+      .where('session.status IN (:...statuses)', {
+        statuses: [GameSessionStatus.ACTIVE, GameSessionStatus.PAUSED],
+      })
+      .andWhere('session.updated_at < :cutoff', { cutoff })
+      .getMany();
+
+    if (staleSessions.length === 0) return 0;
+
+    const now = new Date();
+    for (const session of staleSessions) {
+      session.status = GameSessionStatus.EXPIRED;
+      session.completedAt = now;
+    }
+
+    await this.sessionRepository.save(staleSessions);
+    return staleSessions.length;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Helpers
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Asserts that a transition from `current` to `next` is valid.
+   * Throws BadRequestException if the transition is not permitted.
+   */
+  private assertValidTransition(
+    current: GameSessionStatus,
+    next: GameSessionStatus,
+  ): void {
+    if (TERMINAL_STATES.has(current)) {
+      throw new BadRequestException(
+        `Session is in a terminal state (${current}) and cannot be transitioned.`,
+      );
+    }
+
+    const allowed = SESSION_TRANSITIONS[current];
+    if (!allowed.includes(next)) {
+      throw new BadRequestException(
+        `Invalid status transition: ${current} → ${next}. ` +
+          `Allowed transitions from ${current}: [${allowed.join(', ')}].`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the `game-sessions` NestJS module as specified in #611.

closes #611

---

## What's included

### Entity
- `GameSession` TypeORM entity with all fields from the spec: `userId`, `guestId`, `status`, `difficulty`, `selectedCategories`, `challengeCount`, `currentChallenge`, `score`, `xpEarned`, `startedAt`, `completedAt`.

### State machine
- `GameSessionStatus` enum: `CREATED`, `ACTIVE`, `PAUSED`, `COMPLETED`, `EXPIRED`, `ABANDONED`.
- `SESSION_TRANSITIONS` map enforces valid transitions; terminal-state guard prevents mutations after `COMPLETED / EXPIRED / ABANDONED`.

### Service (`GameSessionsService`)
- `create()` – session creation for authenticated users and guests.
- `findAllByUser()` – list all sessions for a user.
- `findActiveSession()` – retrieve the single active session.
- `findById()` – 404-safe retrieval.
- `findAndVerifyOwnership()` – ownership enforcement (403 for non-owners).
- `updateStatus()` – validated state transitions with side-effects (stamp `startedAt`, `completedAt`, persist `score`/`xpEarned`).
- `completeSession()` – convenience wrapper for marking COMPLETED.
- `expireIdleSessions()` – bulk-expire stale sessions (for scheduled jobs).

### Controller (`GameSessionsController`)
| Method | Endpoint | Description |
|--------|----------|-------------|
| `POST` | `/game-sessions` | Create session |
| `GET` | `/game-sessions` | List all sessions (auth user) |
| `GET` | `/game-sessions/active` | Get current active session |
| `GET` | `/game-sessions/:id` | Get session by ID (ownership checked) |
| `PATCH` | `/game-sessions/:id/status` | Transition session status |

### DTOs
- `CreateGameSessionDto` – with `class-validator` and Swagger decorators.
- `UpdateGameSessionStatusDto` – with optional score/xpEarned for completion.
- `GameSessionResponseDto` – full Swagger-documented response shape.

### Module
- `GameSessionsModule` registered in `AppModule`.

---

## Testing

26 unit tests covering:
- All valid and invalid state transitions
- Session creation (authenticated + guest)
- CRUD operations
- Ownership enforcement (user + guest)
- `expireIdleSessions` bulk expiry

```
Tests: 163 passed, 163 total (19 suites)
```