### PR TITLE
docs: add comprehensive API and environment documentation (#627)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,33 @@
 # Contributing
 
+Thanks for contributing to Mind Block. This document is the process; the
+technical setup lives in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
+
+## Before you start
+
+| I need to... | Read |
+| ------------ | ---- |
+| Set the project up locally | [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) |
+| Know which environment variables to set | [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md) |
+| Understand the codebase layout | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
+| Call or extend the API | [docs/API.md](docs/API.md) |
+| Run tests, lint, and builds | [docs/TESTING.md](docs/TESTING.md) |
+
+## Contributor workflow
+
+1. **Find an issue.** Pick an open issue and comment that you are taking it, or open one describing the problem before writing code. `good first issue` is the easiest entry point.
+2. **Fork and clone.** Work on a fork; branch protection blocks direct pushes to `main` and `develop`.
+3. **Set up.** Follow [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md): Node 20.x, npm, PostgreSQL, Redis, env files.
+4. **Branch from `main`.** Use the naming convention below.
+5. **Make the change.** Keep it scoped to the issue; unrelated refactors make review slower and merges riskier.
+6. **Add tests.** New behaviour needs a spec. See [docs/TESTING.md](docs/TESTING.md).
+7. **Run the local checks.** The full list is below and must pass before you push.
+8. **Commit** using Conventional Commits.
+9. **Open a PR** against `main` with a full description, and link the issue with `closes #<number>`.
+10. **Respond to review** with follow-up commits, keeping the branch up to date with `main`.
+
 ## Import Guidelines
+
 Rule: Always use relative imports.
 
 Bad:
@@ -15,9 +42,10 @@ import X from "../../components/X";
 
 CI will reject PRs containing src/* imports.
 
-Issue/PR: https://github.com/MindBlockLabs/mindBlock_app/pull/0000 (placeholder)
+## Local checks
 
-**MUST RUN** Local check to before submitting a pr:
+**MUST RUN** before submitting a PR:
+
 ```bash
 npm ci
 npm --workspace frontend run build
@@ -28,7 +56,12 @@ npm --workspace backend run lint
 
 npm --workspace frontend exec -- tsc --noEmit -p tsconfig.json
 npm --workspace backend exec -- tsc --noEmit -p tsconfig.json
+
+npm --workspace backend run test
 ```
+
+These mirror the CI jobs, so a clean local run means a green pipeline. Details
+and troubleshooting are in [docs/TESTING.md](docs/TESTING.md).
 
 ## Contract Development
 
@@ -46,20 +79,25 @@ rustup target add wasm32-unknown-unknown
 cargo install --locked stellar-cli
 ```
 
-**MUST RUN** Local checks from inside `contracts/` before submitting a PR:
+**MUST RUN** Local checks from inside `contract/` before submitting a PR:
 
 ```bash
-cd contracts/
+cd contract/
 
 # Check formatting
-cargo fmt --check
+cargo fmt --all -- --check
+
+# Run clippy the way CI does
+cargo clippy --locked --all-targets --all-features -- -D warnings
 
 # Build the contract
 stellar contract build
 
 # Run tests
-cargo test
+cargo test --locked
 ```
+
+The crate directory is `contract/` (singular).
 
 ## Branch Protection
 main and develop require status checks: lint-imports, build, type-check, contracts.
@@ -74,6 +112,7 @@ To maintain a clean commit history and make reviews efficient, all pull requests
   - `feature/your-feature-name`
   - `fix/issue-number`
   - `chore/tooling-update`
+  - `docs/what-you-documented`
 - Avoid vague names like `update` or `patch`.
 
 ### PR Title
@@ -92,6 +131,7 @@ To maintain a clean commit history and make reviews efficient, all pull requests
   - **Solution**: How was it solved?
   - **Acceptance Criteria**: What conditions prove the fix works?
   - **Testing Notes**: How was it tested?
+- Link the issue with `closes #<issue-number>`.
 - Avoid minimal descriptions like only writing `Closes #22`.
 
 ### CI/CD Enforcement
@@ -99,6 +139,24 @@ To maintain a clean commit history and make reviews efficient, all pull requests
   - Have non-compliant titles (e.g., `update`, `fix bug`).
   - Have descriptions shorter than 20 characters or missing context.
 - The `build-and-deploy` job depends on PR validation, so failing validation will block merges.
+
+## Code Standards
+
+- **TypeScript everywhere** in `backend/` and `frontend/`; avoid `any` where a real type is expressible.
+- **Backend layering**: HTTP concerns in controllers, business rules in providers, persistence in entities and repositories. See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+- **DTOs are the contract**: the global `ValidationPipe` runs with `forbidNonWhitelisted`, so any accepted field must be declared and validated on a DTO.
+- **Document new endpoints** with `@ApiOperation` and `@ApiResponse` so Swagger at `/api` stays complete, and update the matching table in [docs/API.md](docs/API.md) in the same PR.
+- **New environment variables** must be added to `backend/.env.example` and documented in [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md).
+- **Never commit secrets.** Env files are git-ignored; keep them that way.
+- **Formatting** is handled by Prettier and ESLint. Run `npm --workspace backend run format` rather than hand-formatting.
+
+## Documentation changes
+
+Docs are part of the product. If your change alters setup steps, configuration,
+endpoints, or commands, update the affected file under `docs/` in the same pull
+request. The acceptance bar is simple: a new contributor should be able to go
+from clone to a running stack with passing tests using only what is committed
+here.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,82 +22,180 @@ Whether you're a beginner or a pro, **Mind Block adapts to you**—making every 
 
 ---
 
+## 📚 Documentation
+
+| Document | What it covers |
+| -------- | -------------- |
+| [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) | Full local setup, running each service, migrations, seed data, common errors |
+| [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md) | Every backend, frontend, and Stellar environment variable |
+| [docs/API.md](docs/API.md) | REST API reference: endpoints, payloads, auth, errors |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Monorepo layout, request lifecycle, data stores, deployment |
+| [docs/TESTING.md](docs/TESTING.md) | Test, lint, type-check, and build commands, plus what CI enforces |
+| [docs/CANONICAL_DOMAIN_MODEL.md](docs/CANONICAL_DOMAIN_MODEL.md) | Authoritative domain model specification |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Contributor workflow, branch and PR standards |
+
+---
+
 ## 🏗️ Project Structure
 This is a **monorepo** containing three main components:
 
-- **Backend (NestJS)** – API & game logic  
-- **Frontend (NextJS)** – User interface  
-- **Smart Contracts (Soroban)** – Stellar testnet deployment  
+- **Backend (NestJS)** – API & game logic (`backend/`)
+- **Frontend (Next.js)** – User interface (`frontend/`)
+- **Smart Contract (Soroban)** – Stellar testnet deployment (`contract/`)
+
+A full directory breakdown is in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ### 🌍 Hosting
 - **Backend (NestJS)** → [Render](https://mindblock-webaapp.onrender.com)  
 - **Frontend (NextJS)** → [Vercel](https://mind-block-app-frontend.vercel.app/)  
-- **Contracts (Rust)** → Stellar testnet  
+- **Contract (Rust)** → Stellar testnet  
+
+---
+
+## ✅ Prerequisites
+
+| Tool | Version | Required for |
+| ---- | ------- | ------------ |
+| Node.js | **20.x LTS (>= 20.9.0)** | Backend and frontend. CI pins Node 20.x; Next.js 16 needs >= 20.9. |
+| npm | **10.x** (ships with Node 20) | The repo uses npm workspaces and a committed `package-lock.json`. Do not use yarn, pnpm, or bun. |
+| PostgreSQL | **14+** | Backend datastore. |
+| Redis | **6+** | Sessions, JWT state, caching. The backend will not start without it. |
+| Rust + `wasm32-unknown-unknown` | stable | Only if you work on `contract/`. |
+| Stellar CLI | latest | Only for building or deploying the contract. |
 
 ---
 
 ## ⚡ Getting Started
 
-Follow these steps to clone and set up the project locally.
+The path from clone to a running stack, in order.
 
-### 1. Clone the repository
+### 1. Clone
+
 ```bash
 git clone https://github.com/MindBlockLabs/mindBlock_app.git
 cd mindBlock_app
 ```
 
-2. Install dependencies
-
-Each package has its own dependencies. You can install them separately or at ones:
-Instructions can be found in the general package.json file (script). It is advisable though to install seperately and focus on the folder your isuue is specific to.
-
-Backend (NestJS)
-cd backend
-npm install
-
-Frontend (NextJS)
-cd frontend
-npm install
-
-Contracts (Soroban)
-
-Make sure you have Scarb
- and Stellar CLI installed, then:
-
-cd contracts
-scarb build
-
-3. Environment variables
-
-Create a .env file inside the backend and/or frontend folders.
-For backend:
+### 2. Install
 
 ```bash
-REDIS_URL=redis://127.0.0.1:6379
-DATABASE_API='https://mindblock-webaapp.onrender.com/api'
-
+npm ci
 ```
 
-For frontend:
+This installs every workspace from the lockfile in one pass. You can also
+install a single package (`cd backend && npm install`) if you only work there.
 
-NEXT_PUBLIC_API_URL=http://localhost:5000
+### 3. Configure
 
-4. Run the project
-Backend
+```bash
+cp backend/.env.example backend/.env
+printf 'NEXT_PUBLIC_API_URL=http://localhost:3000\n' > frontend/.env.local
+```
+
+Fill in at minimum `REDIS_URL`, `JWT_SECRET`, and the `DATABASE_*` block in
+`backend/.env`. Every variable is documented in
+[docs/ENVIRONMENT.md](docs/ENVIRONMENT.md).
+
+### 4. Start PostgreSQL
+
+```bash
+docker run --name mindblock-postgres \
+  -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password \
+  -e POSTGRES_DB=mindblock -p 5432:5432 -d postgres:16
+```
+
+Or use a local install and `createdb mindblock`. The credentials must match
+`backend/.env`.
+
+### 5. Start Redis
+
+```bash
+docker run --name mindblock-redis -p 6379:6379 -d redis:7
+redis-cli ping   # -> PONG
+```
+
+### 6. Run the backend
+
+```bash
 cd backend
 npm run start:dev
+```
 
-Frontend
+- API: <http://localhost:3000>
+- Swagger UI: <http://localhost:3000/api>
+- Health: <http://localhost:3000/health>
+
+### 7. Run the frontend
+
+In a second terminal:
+
+```bash
 cd frontend
 npm run dev
+```
 
-Contracts
+Next.js picks a free port (typically 3001 while the backend holds 3000); the
+terminal prints the URL.
 
-Deploy your Soroban contracts on Stellar testnet:
+From the repo root you can also start either service without changing directory:
 
-cd contracts
-stellar-compile
-stellar-deploy
+```bash
+npm run dev:backend
+npm run dev:frontend
+```
+
+> `npm run dev` starts both through `concurrently`, which is not currently
+> declared as a dependency. Until it is, either run the two commands above in
+> separate terminals or install it yourself (`npm i -D concurrently`).
+
+### 8. Run the tests
+
+```bash
+npm --workspace backend run test
+npm --workspace backend run test:e2e
+```
+
+Lint, type-check, and build commands are in
+[docs/TESTING.md](docs/TESTING.md).
+
+### 9. Contract (optional)
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo install --locked stellar-cli
+
+cd contract
+cargo build --locked --target wasm32-unknown-unknown --release
+cargo test --locked
+```
+
+Deployment identities and network setup are covered in
+[docs/ENVIRONMENT.md](docs/ENVIRONMENT.md#3-stellar-and-soroban-shell-environment).
+
+---
+
+## 🛠️ Common commands
+
+| Command | Runs from | What it does |
+| ------- | --------- | ------------ |
+| `npm --workspace backend run start:dev` | root | Backend in watch mode |
+| `npm --workspace frontend run dev` | root | Frontend dev server |
+| `npm --workspace backend run test` | root | Backend unit tests |
+| `npm --workspace backend run test:cov` | root | Backend coverage |
+| `npm --workspace backend run lint` | root | Backend ESLint |
+| `npm --workspace frontend run lint` | root | Frontend ESLint |
+| `npm --workspace backend run build` | root | Compile the backend |
+| `npm --workspace frontend run build` | root | Production frontend build |
+
+---
+
+## 🚑 Troubleshooting
+
+Hitting `REDIS_URL not defined`, `ECONNREFUSED 5432`, `EADDRINUSE :::3000`, or a
+`401` on every request? Each of those, and more, is covered in
+[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#12-common-errors).
+
+---
 
 ## 👥 Contributors & Contact
 
@@ -111,21 +209,25 @@ amalikabdulmalik04@gmail.com
 
 ## Contribution Guidelines
 
-We ❤️ contributions!
+We ❤️ contributions! The full workflow, branch naming rules, PR standards, and
+CI requirements live in [CONTRIBUTING.md](CONTRIBUTING.md). The short version:
 
-Fork the repo
+1. Fork the repo and branch from `main`:
 
-Create a new branch:
-
+```bash
 git checkout -b feature/your-feature-name
+```
 
+2. Make your change and run the checks in [docs/TESTING.md](docs/TESTING.md).
 
-Commit changes with clear messages:
+3. Commit with a Conventional Commits message:
 
+```bash
 git commit -m "feat: add puzzle leaderboard"
+```
 
-
-Push and open a Pull Request (PR).
+4. Push and open a Pull Request describing the problem, the solution, the
+   acceptance criteria, and how you tested it.
 
 💡 For issues/bugs, please open an issue.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,521 @@
+# API Reference
+
+The Mind Block backend is a NestJS HTTP API. This document is a hand-written
+overview of the surface area; the generated, always-current contract is the
+Swagger UI the app serves at runtime.
+
+| Environment | Base URL | Swagger UI |
+| ----------- | -------- | ---------- |
+| Local | `http://localhost:3000` | <http://localhost:3000/api> |
+| Hosted | `https://mindblock-webaapp.onrender.com` | `https://mindblock-webaapp.onrender.com/api` |
+
+The Swagger document is built in `backend/src/main.ts` and mounted at `/api`.
+
+---
+
+## Conventions
+
+### Content type
+
+All request and response bodies are JSON. Send `Content-Type: application/json`
+on any request with a body.
+
+### Authentication
+
+Authentication is a JWT bearer token:
+
+```http
+Authorization: Bearer <accessToken>
+```
+
+`JwtAuthMiddleware` is applied globally in `backend/src/app.module.ts` and
+excludes only these public prefixes:
+
+- `/auth/*`
+- `/api` (Swagger UI)
+- `/docs`
+- `/health`
+
+Every other route requires a valid token. Obtain one from `POST /auth/signIn`,
+`POST /auth/stellar-wallet-login`, or the Google endpoint, and refresh it with
+`POST /auth/refreshToken`.
+
+Handlers that use the `@ActiveUser()` decorator read the user from the verified
+token, so you do not pass a user ID for those endpoints.
+
+### Validation
+
+A global `ValidationPipe` runs with `whitelist: true`,
+`forbidNonWhitelisted: true`, and `transform: true`. Unknown properties are a
+`400`, not a silent strip:
+
+```json
+{
+  "statusCode": 400,
+  "message": ["property nickname should not exist"],
+  "error": "Bad Request"
+}
+```
+
+### Errors
+
+`AllExceptionsFilter` catches everything, so non-HTTP exceptions still return
+structured JSON rather than a raw stack trace. Every request is stamped with a
+correlation ID by `CorrelationIdMiddleware`; include it when reporting a bug.
+
+| Status | Meaning |
+| ------ | ------- |
+| 400 | Validation failure or malformed payload. |
+| 401 | Missing, expired, or invalid bearer token. |
+| 403 | Authenticated but not permitted (admin routes, shutdown, bad admin key). |
+| 404 | Resource does not exist. |
+| 429 | Rate limit exceeded (`@nestjs/throttler`). |
+| 500 | Unhandled server error. |
+
+### Rate limiting
+
+Throttling is applied per route where it matters, for example
+`GET /auth/stellar-wallet-nonce` allows 5 requests per minute and
+`POST /analytics/track` allows 20 per minute.
+
+### Pagination
+
+List endpoints that paginate accept:
+
+| Query | Type | Default |
+| ----- | ---- | ------- |
+| `page` | positive integer | `1` |
+| `limit` | positive integer | `10` |
+
+Paginated responses carry `data`, a `meta` block (`itemsPerPage`, `totalItems`,
+`currentPage`, `totalPages`) and a `links` block (`first`, `last`, `current`,
+`previous`, `next`).
+
+### CORS
+
+CORS is currently open (`origin: '*'`) with `GET`, `POST`, `PUT`, `DELETE`, and
+`OPTIONS` allowed, and `Content-Type` and `Authorization` accepted as headers.
+
+---
+
+## Endpoint index
+
+| Area | Base path | Auth |
+| ---- | --------- | ---- |
+| Root | `/` | Public |
+| Auth | `/auth` | Public |
+| Google auth | `/auth/google-authentication` | Public |
+| Health | `/health` | Public (`/health/detailed` needs an admin key) |
+| Users | `/users` | Bearer |
+| Puzzles | `/puzzles` | Bearer |
+| Categories | `/categories` | Bearer |
+| Game sessions | `/game-sessions` | Bearer or guest ID |
+| Challenge attempts | `/challenge-attempts` | Bearer |
+| Progress | `/progress` | Bearer |
+| Daily quest | `/daily-quest` | Bearer |
+| Streaks | `/streaks` | Bearer |
+| Analytics | `/analytics` | Bearer (retention is admin-only) |
+| Blockchain | `/blockchain` | Bearer |
+| Admin IQ questions | `/admin/iq-questions` | Bearer + `ADMIN` role |
+
+---
+
+## 1. Root
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/` | Service greeting from `AppController`. |
+
+---
+
+## 2. Auth (`/auth`)
+
+All routes are public.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/auth/signIn` | Email and password sign-in. |
+| `POST` | `/auth/refreshToken` | Exchange a refresh token for a new access token. |
+| `POST` | `/auth/guest-session` | Create a 15-minute guest session. Returns `201`. |
+| `GET` | `/auth/guest-session/:sessionId/status` | Guest session status and expiry. |
+| `POST` | `/auth/guest-session/:sessionId/hint` | Consume a guest hint. Max 2; `403` once exhausted. |
+| `POST` | `/auth/convert-guest` | Convert a guest session into a real account. |
+| `GET` | `/auth/stellar-wallet-nonce?walletAddress=G...` | Nonce to sign. Expires in 5 minutes. Throttled to 5/min. |
+| `GET` | `/auth/stellar-wallet-nonce/status` | Inspect an issued nonce. |
+| `POST` | `/auth/stellar-wallet-login` | Log in with a signed nonce. |
+| `POST` | `/auth/forgot-password` | Send a password reset mail. |
+| `POST` | `/auth/reset-password/:token` | Set a new password using the emailed token. |
+| `POST` | `/auth/google-authentication` | Exchange a Google ID token for app credentials. |
+
+### `POST /auth/signIn`
+
+```json
+{
+  "email": "player@example.com",
+  "password": "Password123!"
+}
+```
+
+Returns the access token (and refresh token) used for every protected route.
+`401` on invalid credentials.
+
+### `POST /auth/refreshToken`
+
+```json
+{ "refreshToken": "some-refresh-token" }
+```
+
+`400` when the refresh token is invalid or expired.
+
+### Stellar wallet login
+
+Three steps:
+
+```bash
+# 1. Ask for a nonce
+curl "http://localhost:3000/auth/stellar-wallet-nonce?walletAddress=GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A"
+# -> { "nonce": "stellar_nonce_...", "expiresAt": 1693123756789 }
+
+# 2. Sign the nonce in the wallet (Freighter, xBull, Albedo)
+
+# 3. Exchange the signature for a token
+curl -X POST http://localhost:3000/auth/stellar-wallet-login \
+  -H "Content-Type: application/json" \
+  -d '{
+    "walletAddress": "GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A",
+    "signature": "base64SignatureString==",
+    "nonce": "stellar_nonce_1693123456789_abc123_BTODB4A",
+    "publicKey": "GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A"
+  }'
+# -> { "accessToken": "..." }
+```
+
+`400` for a malformed address or an expired nonce, `401` for a bad signature.
+
+### `POST /auth/convert-guest`
+
+```json
+{
+  "guestSessionId": "guest_...",
+  "email": "player@example.com",
+  "password": "Password123!",
+  "walletAddress": "G..."
+}
+```
+
+`email`/`password` and `walletAddress` are both optional individually; supply
+whichever identity the player is upgrading to.
+
+### Password reset
+
+```json
+// POST /auth/forgot-password
+{ "email": "player@example.com" }
+
+// POST /auth/reset-password/:token
+{ "password": "NewPassword123!" }
+```
+
+Requires working SMTP configuration; see
+[ENVIRONMENT.md](./ENVIRONMENT.md#17-mail-smtp).
+
+---
+
+## 3. Health (`/health`)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/health` | Basic liveness plus status summary. |
+| `GET` | `/health/live` | Kubernetes liveness probe. |
+| `GET` | `/health/ready` | Readiness probe. `403` when dependencies are unhealthy. |
+| `GET` | `/health/detailed` | Full dependency detail. Requires the `x-admin-key` header to match `ADMIN_HEALTH_KEY`. |
+
+During graceful shutdown these endpoints return `403` so load balancers drain
+traffic before the process exits.
+
+```bash
+curl -H "x-admin-key: $ADMIN_HEALTH_KEY" http://localhost:3000/health/detailed
+```
+
+---
+
+## 4. Users (`/users`)
+
+Bearer token required.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/users?page=1&limit=10` | Paginated user list. |
+| `GET` | `/users/:id` | Single user. |
+| `GET` | `/users/:id/xp-level` | XP total and derived level. |
+| `POST` | `/users` | Create a user. |
+| `PATCH` | `/users/:id` | Update a user profile. |
+| `DELETE` | `/users/:id` | Delete a user. |
+
+`POST /users` accepts `email`, `username`, `fullname`, `password`, `userRole`,
+`walletAddress`, `publicKey`, `provider`, and `googleId`; all are optional at the
+DTO level, so supply the identity fields relevant to the account type.
+
+`PATCH /users/:id` accepts `name`, `username`, and `avatar`.
+
+---
+
+## 5. Puzzles (`/puzzles`)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/puzzles` | Create a puzzle. `201` on success. |
+| `GET` | `/puzzles` | List puzzles, filterable. |
+| `GET` | `/puzzles/daily-quest` | Puzzles making up today's daily quest. |
+| `GET` | `/puzzles/:id` | Single puzzle. |
+
+Create body:
+
+```json
+{
+  "question": "Which data structure gives O(1) average lookup?",
+  "options": ["Array", "Hash map", "Linked list", "Binary tree"],
+  "correctAnswer": "Hash map",
+  "difficulty": "INTERMEDIATE",
+  "categoryId": "8e2f...",
+  "points": 20,
+  "timeLimit": 60,
+  "explanation": "Hashing gives constant-time average access."
+}
+```
+
+`points` and `explanation` are optional. `400` if the category does not exist or
+is inactive.
+
+List filters:
+
+| Query | Description |
+| ----- | ----------- |
+| `categoryId` | Restrict to one category. |
+| `difficulty` | One of the `PuzzleDifficulty` values: `BEGINNER`, `INTERMEDIATE`, `ADVANCED`, `EXPERT`. |
+
+---
+
+## 6. Categories (`/categories`)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/categories` | Create a category. |
+| `GET` | `/categories?isActive=true` | List categories, optionally filtered by active state. |
+
+```json
+{
+  "name": "Logic",
+  "description": "Deductive reasoning puzzles",
+  "icon": "brain",
+  "isActive": true
+}
+```
+
+Only `name` is required.
+
+---
+
+## 7. Game sessions (`/game-sessions`)
+
+A game session is one play-through: a set of challenges, a score, and XP.
+Authenticated players are identified by their token; guests pass `guestId`.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/game-sessions` | Start a session. |
+| `GET` | `/game-sessions` | Sessions for the current user. |
+| `GET` | `/game-sessions/active` | The user's currently active session. |
+| `GET` | `/game-sessions/:id?guestId=...` | Fetch one session. `:id` must be a UUID. |
+| `PATCH` | `/game-sessions/:id/status?guestId=...` | Update status, score, and XP. |
+
+Create body:
+
+```json
+{
+  "challengeCount": 10,
+  "difficulty": "INTERMEDIATE",
+  "selectedCategories": ["8e2f...", "b41c..."],
+  "guestId": "guest_..."
+}
+```
+
+Only `challengeCount` is required; `guestId` is for unauthenticated play.
+
+Status update body (`GameSessionStatus`: `CREATED`, `ACTIVE`, `PAUSED`, `COMPLETED`, `EXPIRED`, `ABANDONED`):
+
+```json
+{ "status": "COMPLETED", "score": 80, "xpEarned": 120 }
+```
+
+Response shape: `id`, `status`, `challengeCount`, `currentChallenge`, `score`,
+`xpEarned`, `createdAt`, `updatedAt`.
+
+---
+
+## 8. Challenge attempts (`/challenge-attempts`)
+
+The execution ledger: one record per challenge a player takes on.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/challenge-attempts` | Begin an attempt. |
+| `POST` | `/challenge-attempts/submit` | Submit an answer. |
+| `PATCH` | `/challenge-attempts/hint` | Consume a hint. |
+| `PATCH` | `/challenge-attempts/reveal` | Reveal the solution. |
+| `PATCH` | `/challenge-attempts/:id/expire` | Mark an attempt expired. |
+| `GET` | `/challenge-attempts/:id` | One attempt. |
+| `GET` | `/challenge-attempts/user/:userId` | All attempts by a user. |
+| `GET` | `/challenge-attempts/session/:sessionId` | All attempts in a session. |
+
+```json
+// POST /challenge-attempts
+{ "userId": "...", "challengeId": "...", "sessionId": "..." }
+
+// POST /challenge-attempts/submit
+{ "attemptId": "...", "answer": "Hash map", "timeSpent": 24 }
+
+// PATCH /challenge-attempts/hint  and  /reveal
+{ "attemptId": "..." }
+```
+
+`timeSpent` is in seconds. Scoring is decided server-side.
+
+---
+
+## 9. Progress (`/progress`)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/progress?page=1&limit=10` | Paginated attempt history for the current user. |
+| `GET` | `/progress/stats` | Overall statistics. |
+| `GET` | `/progress/category/:id` | Statistics for one category. |
+| `POST` | `/progress/submit` | Submit an answer and record progress. |
+
+History entries contain `id`, `puzzleId`, `question`, `userAnswer`,
+`isCorrect`, `pointsEarned`, `timeSpent`, `attemptedAt`, and `categoryId`.
+
+`GET /progress/stats` returns `totalAttempts`, `totalCorrect`, `accuracy`,
+`totalPointsEarned`, and `totalTimeSpent`. The category variant returns
+`categoryId`, `categoryName`, `totalAttempts`, `correctAnswers`, and `accuracy`.
+
+```json
+// POST /progress/submit
+{
+  "userId": "...",
+  "puzzleId": "...",
+  "categoryId": "...",
+  "userAnswer": "Hash map",
+  "timeSpent": 24
+}
+```
+
+---
+
+## 10. Daily quest (`/daily-quest`)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/daily-quest` | Today's quest with its puzzles. |
+| `GET` | `/daily-quest/status` | Progress counters only. |
+| `POST` | `/daily-quest/complete` | Finalize the quest, award bonus XP, update the streak. |
+
+`POST /daily-quest/complete` is idempotent: repeated calls do not duplicate
+rewards. It returns `success`, `message`, `bonusXp`, `totalXp`, a `streak`
+object (`currentStreak`, `longestStreak`, `lastActivityDate`), and `completedAt`.
+`400` if the quest is not fully solved, `404` if no quest exists for today.
+
+Quest payloads carry `id`, `questDate`, `totalQuestions`, `completedQuestions`,
+`isCompleted`, `pointsEarned`, `createdAt`, `completedAt`, and `puzzles`. Puzzle
+entries in a quest never include the correct answer.
+
+---
+
+## 11. Streaks (`/streaks`)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/streaks` | The current user's streak record. |
+| `POST` | `/streaks/update` | Recalculate the streak after a daily quest completion. |
+
+The user is taken from the bearer token; `401` when it is missing or invalid.
+
+---
+
+## 12. Analytics (`/analytics`)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/analytics/ping` | Module health check. |
+| `POST` | `/analytics/track` | Record an event. Throttled to 20 requests per minute. |
+| `GET` | `/analytics/funnel/onboarding?start=&end=` | Onboarding funnel over a date range. |
+| `GET` | `/analytics/users/retention?start=&end=&granularity=` | Retention curve. Admin role required. |
+
+```json
+// POST /analytics/track
+{ "eventType": "onboarding_started", "userId": "..." }
+// -> { "success": true }
+```
+
+`start` and `end` are ISO date strings. Non-admin callers get `403` from
+`AnalyticsAdminGuard` on the retention endpoint.
+
+---
+
+## 13. Blockchain (`/blockchain`)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/blockchain` | Blockchain module status. |
+| `POST` | `/blockchain/wallet/link` | Link a Stellar wallet to the signed-in account. |
+
+```json
+{ "walletAddress": "GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A" }
+```
+
+---
+
+## 14. Admin: IQ questions (`/admin/iq-questions`)
+
+Requires a bearer token whose user holds the `ADMIN` role; enforced by
+`RolesGuard`.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/admin/iq-questions` | Create an IQ question. |
+| `DELETE` | `/admin/iq-questions/:id` | Delete an IQ question. |
+
+These handlers are stubs today and return acknowledgement messages.
+
+---
+
+## Quick start with curl
+
+```bash
+# 1. Sign in
+TOKEN=$(curl -s -X POST http://localhost:3000/auth/signIn \
+  -H "Content-Type: application/json" \
+  -d '{"email":"player@example.com","password":"Password123!"}' \
+  | python -c "import json,sys; print(json.load(sys.stdin)['accessToken'])")
+
+# 2. Call a protected route
+curl http://localhost:3000/progress/stats -H "Authorization: Bearer $TOKEN"
+
+# 3. Start a game session
+curl -X POST http://localhost:3000/game-sessions \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"challengeCount":10,"difficulty":"INTERMEDIATE"}'
+```
+
+`backend/src/endpoint.http` and `backend/http/` hold ready-made requests you can
+fire from the VS Code REST Client extension.
+
+---
+
+## Keeping this document accurate
+
+Swagger is generated from decorators, so a new endpoint appears at `/api`
+automatically once you annotate it with `@ApiOperation` and `@ApiResponse`. When
+you add or change a route, update the matching table here in the same pull
+request.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,246 @@
+# Architecture
+
+How the Mind Block monorepo is laid out, what each piece is responsible for, and
+how a request travels through the system. For the domain entities themselves,
+read [CANONICAL_DOMAIN_MODEL.md](./CANONICAL_DOMAIN_MODEL.md), which is the
+authoritative specification.
+
+---
+
+## 1. High-level shape
+
+```text
+                +---------------------------+
+                |  Frontend (Next.js 16)    |
+                |  App Router, React 19,    |
+                |  Redux Toolkit, Tailwind  |
+                +-------------+-------------+
+                              | HTTPS / JSON
+                              v
+                +---------------------------+          +--------------+
+                |  Backend (NestJS 11)      |<-------->|  PostgreSQL  |
+                |  REST API, JWT auth,      |  TypeORM +--------------+
+                |  domain modules, Swagger  |
+                +------+-------------+------+          +--------------+
+                       |             |<--------------->|    Redis     |
+                       |                     ioredis   +--------------+
+                       v
+            +-----------------------+
+            | Stellar / Soroban     |
+            | wallet auth, rewards  |
+            +-----------------------+
+                       ^
+                       | Freighter, xBull, Albedo
+            +-----------------------+
+            | Player's wallet       |
+            +-----------------------+
+```
+
+The frontend never talks to the database. All scoring, verification, and reward
+eligibility are decided by the backend, which is the single authority.
+
+---
+
+## 2. Repository layout
+
+```text
+mindBlock_app/
+├── backend/          NestJS API (TypeScript)
+│   ├── src/
+│   │   ├── analytics/          Event tracking, funnels, retention
+│   │   ├── auth/               Sign-in, JWT, guest sessions, wallet + Google auth
+│   │   ├── blockchain/         Stellar wallet linking and on-chain interaction
+│   │   ├── categories/         Puzzle categories
+│   │   ├── challenge-attempt/  Per-challenge execution ledger
+│   │   ├── common/             Filters, middleware, pagination, shared helpers
+│   │   ├── config/             appConfig and databaseConfig registrations
+│   │   ├── database/migrations/ TypeORM migrations
+│   │   ├── domain/             Canonical enums and domain interfaces
+│   │   ├── game-sessions/      Play-through lifecycle
+│   │   ├── health/             Liveness, readiness, detailed health
+│   │   ├── progress/           Progress history and statistics
+│   │   ├── puzzles/            Puzzle content
+│   │   ├── quests/             Daily quest system
+│   │   ├── redis/              Redis client provider
+│   │   ├── rewards/            Reward logic
+│   │   ├── roles/              Role decorator and guard
+│   │   ├── score/              Scoring helpers
+│   │   ├── streak/             Daily streak tracking
+│   │   ├── users/              User accounts and profiles
+│   │   ├── app.module.ts       Root module and global middleware wiring
+│   │   └── main.ts             Bootstrap, Swagger, CORS, graceful shutdown
+│   ├── test/                   E2E specs
+│   └── data-source.ts          Standalone TypeORM CLI data source
+├── frontend/         Next.js App Router client
+│   ├── app/                    Routes: auth, dashboard, puzzles, quiz, streak, ...
+│   ├── components/, src/components/  UI components
+│   ├── features/, lib/features/      Feature-scoped state and logic
+│   ├── lib/                    api clients, stellar helpers, analytics, utils
+│   ├── hooks/, providers/, styles/
+│   └── docs/                   Design tokens and onboarding integration notes
+├── contract/         Soroban smart contract (Rust)
+├── shared/           Cross-package types and legacy network config
+├── docs/             This documentation set
+└── .github/workflows/ CI and CI/CD pipelines
+```
+
+The root `package.json` declares npm workspaces. `frontend` and `backend` are
+the two that exist today; the `contracts` and `middleware` entries in that list
+are historical and do not correspond to directories (the Rust crate lives in
+`contract/`, singular, and is built by cargo rather than npm).
+
+---
+
+## 3. Backend
+
+### Framework and layering
+
+NestJS 11 with the standard module / controller / provider layering:
+
+- **Module** wires a feature's dependencies (`puzzles.module.ts`).
+- **Controller** owns HTTP: routing, DTO binding, Swagger annotations (`puzzles.controller.ts`).
+- **Provider / service** holds business logic. Larger features split logic into one provider per use case under `providers/` (see `auth/providers/` and `analytics/providers/`).
+- **Entity** is the TypeORM persistence model (`entities/*.entity.ts`).
+- **DTO** defines and validates the request and response contract with `class-validator` (`dtos/*.dto.ts`).
+
+Keep HTTP concerns in controllers and business rules in providers; controllers
+should stay thin.
+
+### Request lifecycle
+
+```text
+HTTP request
+  -> CorrelationIdMiddleware   stamps a correlation ID for tracing
+  -> GeolocationMiddleware     resolves coarse location from the IP (geoip-lite)
+  -> JwtAuthMiddleware         verifies the bearer token, unless the route is public
+  -> Guards                    RolesGuard, AnalyticsAdminGuard where declared
+  -> ValidationPipe (global)   whitelist + forbidNonWhitelisted + transform
+  -> Controller handler
+  -> Provider / service        business rules
+  -> TypeORM repository        PostgreSQL
+  -> Response
+  (any throw) -> AllExceptionsFilter -> structured JSON error
+```
+
+Public prefixes excluded from `JwtAuthMiddleware` are `/auth/*`, `/api`,
+`/docs`, and `/health`. Everything else needs a token. See
+[API.md](./API.md#authentication).
+
+### Cross-cutting concerns
+
+| Concern | Implementation |
+| ------- | -------------- |
+| Configuration | `@nestjs/config` with `registerAs` namespaces: `appConfig`, `database`, `jwt`. Global module, loaded from `backend/.env`. |
+| Persistence | TypeORM over PostgreSQL, configured asynchronously in `app.module.ts`. `DATABASE_URL` takes priority over the discrete `DATABASE_*` variables. |
+| Caching and sessions | `ioredis` through a single `REDIS_CLIENT` provider in `redis/redis.provider.ts`. |
+| Auth | JWT access and refresh tokens, plus Stellar wallet signatures and Google OAuth. |
+| Authorization | `@Roles()` decorator with `RolesGuard`; analytics has its own admin guard. |
+| Rate limiting | `@nestjs/throttler`, applied per route with `@Throttle`. |
+| Scheduled work | `@nestjs/schedule` (`ScheduleModule.forRoot()`), for example daily quest rollovers. |
+| Events | `@nestjs/event-emitter`, so side effects such as progress updates, streak evaluation, and reward minting stay decoupled from the request path. |
+| Documentation | `@nestjs/swagger`, served at `/api`. |
+| Error handling | `AllExceptionsFilter` catches every throwable, not only `HttpException`. |
+| Shutdown | `SIGTERM` and `SIGINT` flip health checks to unhealthy, wait for load balancers to drain, then close the app. |
+
+### Domain flow
+
+A typical play-through:
+
+```text
+POST /game-sessions            create a GameSession (authenticated or guest)
+POST /challenge-attempts       open an attempt for a challenge in that session
+POST /challenge-attempts/submit  answer; the backend grades it
+  -> emits domain events: progress update, streak evaluation, reward check
+PATCH /game-sessions/:id/status  close the session with score and XP
+GET  /progress/stats           read back aggregates
+```
+
+Guest players get the same flow through a guest session (15 minutes, at most two
+hints) and can convert to a real account via `POST /auth/convert-guest` without
+losing progress.
+
+---
+
+## 4. Frontend
+
+- **Next.js 16 App Router** with React 19; routes are directories under `frontend/app/`.
+- **State**: Redux Toolkit with `react-redux` for app state, TanStack Query for server state.
+- **Styling**: Tailwind CSS v4 with `class-variance-authority`, `clsx`, and `tailwind-merge`; design tokens are documented in `frontend/docs/DESIGN_TOKENS.md`.
+- **UI primitives**: Radix (avatar, slot, tabs), `lucide-react` icons, `framer-motion` animation, `recharts` charts, `@monaco-editor/react` for coding challenges.
+- **Wallets**: `@stellar/freighter-api` plus `stellar-sdk`; wallet helpers live in `frontend/lib/stellar/`.
+- **API access**: `frontend/lib/api/` against `NEXT_PUBLIC_API_URL`.
+
+The backend is the source of truth for scoring, so the client renders state and
+submits intent rather than computing outcomes.
+
+---
+
+## 5. Smart contract
+
+`contract/` is a Soroban contract built with `soroban-sdk` 23 and deployed to
+the Stellar testnet. It backs on-chain rewards for challenge completion.
+
+The release profile is tuned for wasm size (`opt-level = "z"`, LTO, symbols
+stripped, `panic = "abort"`). `ed25519-dalek` is pinned to `=2.2.0`; the comment
+in `Cargo.toml` explains why, and that pin should not be bumped casually.
+
+Wallet-based authentication does not require the contract: it verifies an
+ed25519 signature over a server-issued nonce, entirely off-chain.
+
+---
+
+## 6. Data stores
+
+### PostgreSQL
+
+The system of record: users, puzzles, categories, game sessions, challenge
+attempts, progress, quests, streaks, analytics events. Accessed only through
+TypeORM repositories.
+
+Schema management is currently in transition: local development leans on
+`synchronize`, while `backend/src/database/migrations/` holds explicit
+migrations. The caveats are spelled out in
+[DEVELOPMENT.md](./DEVELOPMENT.md#9-migrations).
+
+### Redis
+
+Session and token state for the JWT middleware, including blacklisting, plus
+caching for hot reads. A missing `REDIS_URL` is fatal at boot by design, so
+failures show up immediately rather than at first cache read.
+
+---
+
+## 7. Deployment
+
+| Component | Host | Notes |
+| --------- | ---- | ----- |
+| Backend | Render | Uses `DATABASE_URL`; `npm run build` then `npm run start:prod`. |
+| Frontend | Vercel | `next build`; `NEXT_PUBLIC_API_URL` points at the Render backend. |
+| Contract | Stellar testnet | Deployed with the Stellar CLI. |
+
+`/health/ready` is the readiness probe; it reports unhealthy during shutdown so
+traffic drains before the process exits.
+
+---
+
+## 8. Conventions that shape the code
+
+1. **Relative imports only.** Absolute `src/...` imports are rejected by CI.
+2. **DTOs are the contract.** `forbidNonWhitelisted` means an undeclared field is a `400`, so every accepted field must exist on a DTO.
+3. **One provider per use case.** Prefer a new provider over growing a service past its purpose.
+4. **Events for side effects.** Progress, streaks, achievements, and minting react to domain events instead of being inlined into request handlers.
+5. **Backend decides.** Never move scoring or reward eligibility into the client.
+6. **Swagger annotations are mandatory** on new endpoints, so `/api` stays complete.
+
+---
+
+## 9. Where to go next
+
+| Question | Document |
+| -------- | -------- |
+| How do I run this locally? | [DEVELOPMENT.md](./DEVELOPMENT.md) |
+| What configuration does it need? | [ENVIRONMENT.md](./ENVIRONMENT.md) |
+| What endpoints exist? | [API.md](./API.md) |
+| How do I test my change? | [TESTING.md](./TESTING.md) |
+| What are the domain entities? | [CANONICAL_DOMAIN_MODEL.md](./CANONICAL_DOMAIN_MODEL.md) |
+| How do I contribute? | [CONTRIBUTING.md](../CONTRIBUTING.md) |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,412 @@
+# Development Guide
+
+Everything needed to go from a fresh clone to a running stack with passing
+tests. Follow the sections in order the first time.
+
+```text
+clone -> install -> configure -> start PostgreSQL -> start Redis -> run backend -> run frontend -> run tests
+```
+
+---
+
+## 1. Prerequisites
+
+| Tool | Version | Why |
+| ---- | ------- | --- |
+| Node.js | 20.x LTS (>= 20.9.0) | CI pins `node-version: 20.x`; Next.js 16 requires >= 20.9. Node 18 and below will fail the frontend build. |
+| npm | 10.x (ships with Node 20) | The repo is an npm workspaces monorepo with a committed `package-lock.json`. Do not use yarn, pnpm, or bun: they would produce a second lockfile and break `npm ci` in CI. |
+| PostgreSQL | 14 or newer | Primary datastore, accessed through TypeORM. |
+| Redis | 6 or newer | Sessions, JWT blacklisting, caching. |
+| Git | any recent | Version control. |
+| Rust toolchain + `wasm32-unknown-unknown` | stable | Only for `contract/`. |
+| Stellar CLI | latest | Only for building and deploying the Soroban contract. |
+
+Check your versions:
+
+```bash
+node -v   # v20.x
+npm -v    # 10.x
+psql --version
+redis-server --version
+```
+
+If you juggle several Node versions, use `nvm`:
+
+```bash
+nvm install 20
+nvm use 20
+```
+
+---
+
+## 2. Clone and install
+
+```bash
+git clone https://github.com/MindBlockLabs/mindBlock_app.git
+cd mindBlock_app
+npm ci
+```
+
+`npm ci` installs every workspace (`frontend`, `backend`, and the rest) from the
+lockfile in a single pass. Use it rather than `npm install` unless you are
+deliberately adding or upgrading a dependency.
+
+Working inside one package only? You can still install just that package:
+
+```bash
+cd backend && npm install
+cd ../frontend && npm install
+```
+
+Adding a dependency to a workspace from the repo root:
+
+```bash
+npm install <package> --workspace backend
+npm install <package> --workspace frontend
+```
+
+Commit the resulting `package-lock.json` change with your PR.
+
+---
+
+## 3. Configure environment files
+
+```bash
+cp backend/.env.example backend/.env
+printf 'NEXT_PUBLIC_API_URL=http://localhost:3000\n' > frontend/.env.local
+```
+
+Then open `backend/.env` and fill in at minimum `REDIS_URL`, `JWT_SECRET`, and
+the `DATABASE_*` block. Every variable is documented in
+[ENVIRONMENT.md](./ENVIRONMENT.md).
+
+---
+
+## 4. Start PostgreSQL
+
+### Option A: Docker (fastest)
+
+```bash
+docker run --name mindblock-postgres \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=password \
+  -e POSTGRES_DB=mindblock \
+  -p 5432:5432 -d postgres:16
+```
+
+### Option B: Local install
+
+```bash
+# macOS
+brew install postgresql@16 && brew services start postgresql@16
+
+# Ubuntu / Debian
+sudo apt install postgresql && sudo systemctl start postgresql
+
+# Windows: install from https://www.postgresql.org/download/windows/
+```
+
+Create the database once the server is up:
+
+```bash
+createdb mindblock
+# or: psql -U postgres -c "CREATE DATABASE mindblock;"
+```
+
+Verify:
+
+```bash
+psql -U postgres -d mindblock -c "SELECT 1;"
+```
+
+The values you use here must match `DATABASE_USER`, `DATABASE_PASSWORD`,
+`DATABASE_NAME`, `DATABASE_HOST`, and `DATABASE_PORT` in `backend/.env`.
+
+---
+
+## 5. Start Redis
+
+### Option A: Docker
+
+```bash
+docker run --name mindblock-redis -p 6379:6379 -d redis:7
+```
+
+### Option B: Local install
+
+```bash
+# macOS
+brew install redis && brew services start redis
+
+# Ubuntu / Debian
+sudo apt install redis-server && sudo systemctl start redis-server
+
+# Windows: use WSL2, Docker, or Memurai
+```
+
+Verify:
+
+```bash
+redis-cli ping   # -> PONG
+```
+
+The backend refuses to boot without a reachable `REDIS_URL`.
+
+---
+
+## 6. Run the backend
+
+```bash
+cd backend
+npm run start:dev
+```
+
+- API: <http://localhost:3000>
+- Swagger UI: <http://localhost:3000/api>
+- Health: <http://localhost:3000/health>
+
+With `DATABASE_SYNC` enabled, TypeORM creates the schema from the entities on
+first boot, so an empty database is fine.
+
+Other backend scripts:
+
+| Command | What it does |
+| ------- | ------------ |
+| `npm run start` | Start once, no watcher. |
+| `npm run start:dev` | Watch mode, `NODE_ENV=development`. |
+| `npm run start:debug` | Watch mode with the Node inspector attached. |
+| `npm run start:prod` | Run the compiled output in `dist/`. Requires `npm run build` first. |
+| `npm run build` | Compile TypeScript via `tsconfig.build.json`. |
+| `npm run lint` | ESLint over `src`, `apps`, `libs`, `test` with `--fix`. |
+| `npm run format` | Prettier over `src` and `test`. |
+
+---
+
+## 7. Run the frontend
+
+In a second terminal:
+
+```bash
+cd frontend
+npm run dev
+```
+
+The Next.js app starts on <http://localhost:3001> when 3000 is already taken by
+the backend; watch the terminal output for the URL it actually chose, and make
+sure `NEXT_PUBLIC_API_URL` still points at the backend.
+
+| Command | What it does |
+| ------- | ------------ |
+| `npm run dev` | Next.js dev server with Turbopack. |
+| `npm run build` | Production build. |
+| `npm run start` | Serve the production build. |
+| `npm run lint` | ESLint via `eslint-config-next`. |
+
+### Running both at once
+
+From the repo root:
+
+```bash
+npm run dev:backend    # backend only
+npm run dev:frontend   # frontend only
+```
+
+`npm run dev` is meant to start both at once through `concurrently`, but
+`concurrently` is not declared in any `package.json` and is absent from the
+lockfile, so the script fails on a clean install. Run the two commands above in
+separate terminals, or add the dependency yourself with `npm i -D concurrently`.
+Declaring it at the root is a small, welcome PR.
+
+---
+
+## 8. Contract (optional)
+
+Only needed when you are changing Soroban code in `contract/`.
+
+```bash
+# One-time toolchain setup
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup target add wasm32-unknown-unknown
+cargo install --locked stellar-cli
+
+cd contract
+cargo fmt --all -- --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo build --locked --target wasm32-unknown-unknown --release
+cargo test --locked
+```
+
+`stellar contract build` produces the same wasm artifact through the Stellar CLI
+wrapper. Deploy targets and identities are covered in
+[ENVIRONMENT.md](./ENVIRONMENT.md#3-stellar-and-soroban-shell-environment).
+
+Note the directory is `contract/` (singular). Older docs referred to
+`contracts/`.
+
+---
+
+## 9. Migrations
+
+Schema changes live in `backend/src/database/migrations/`, named
+`<timestamp>-<Description>.ts`.
+
+Local development currently relies on TypeORM `synchronize` rather than running
+migrations, so a normal contributor flow does not need them. When you do need
+the CLI, the backend exposes it as a script:
+
+```bash
+cd backend
+npm run typeorm -- migration:show     -d data-source.ts
+npm run typeorm -- migration:run      -d data-source.ts
+npm run typeorm -- migration:revert   -d data-source.ts
+```
+
+Generate a new migration after changing entities:
+
+```bash
+npm run typeorm -- migration:generate src/database/migrations/AddSomething -d data-source.ts
+```
+
+Caveats worth knowing before you touch this area:
+
+- `backend/data-source.ts` reads the `DB_*` variables, not the `DATABASE_*` ones the app uses. Set both (see [ENVIRONMENT.md](./ENVIRONMENT.md#13-typeorm-cli-migrations-only)).
+- Its `migrations` glob resolves to `backend/migrations/`, while the migration files actually live in `backend/src/database/migrations/`. Pass the path explicitly, or fix the data source, when running the CLI.
+- Its `entities` glob is `__dirname + '**/*.entity{.ts,.js}'`, which is missing a path separator and matches nothing.
+- It sets `synchronize: true`; do not point it at a database whose contents you care about.
+
+Aligning that file with the app configuration is a welcome standalone PR.
+
+---
+
+## 10. Seed data
+
+`backend/src/seed.ts` boots a Nest application context and exits. It is a
+scaffold with no seeders wired into it yet, so there is no seed command in
+`package.json`. Run it directly if you are extending it:
+
+```bash
+cd backend
+npx ts-node -r tsconfig-paths/register src/seed.ts
+```
+
+`backend/scripts/create-iq-attempts-table.sql` is a one-off SQL helper you can
+apply with `psql -U postgres -d mindblock -f backend/scripts/create-iq-attempts-table.sql`.
+
+Until seeders exist, create content through the API: `POST /categories`, then
+`POST /puzzles`. See [API.md](./API.md).
+
+---
+
+## 11. Tests, lint, and build
+
+Full detail lives in [TESTING.md](./TESTING.md). The short version:
+
+```bash
+# Tests (backend only for now)
+npm --workspace backend run test
+npm --workspace backend run test:cov
+npm --workspace backend run test:e2e
+
+# Lint
+npm --workspace backend run lint
+npm --workspace frontend run lint
+
+# Type-check
+npm --workspace backend exec -- tsc --noEmit -p tsconfig.json
+npm --workspace frontend exec -- tsc --noEmit -p tsconfig.json
+
+# Build
+npm --workspace backend run build
+npm --workspace frontend run build
+```
+
+Run all of these before opening a pull request; CI enforces the same set.
+
+---
+
+## 12. Common errors
+
+### `REDIS_URL not defined in environment variables`
+
+Redis config is missing. Add `REDIS_URL=redis://127.0.0.1:6379` to
+`backend/.env` and restart. The backend throws this during boot, before it
+listens.
+
+### `ECONNREFUSED 127.0.0.1:6379`
+
+Redis is not running. Start it (`brew services start redis`,
+`sudo systemctl start redis-server`, or the Docker command in section 5) and
+confirm with `redis-cli ping`.
+
+### `ECONNREFUSED 127.0.0.1:5432` or `password authentication failed for user`
+
+PostgreSQL is not running, or the credentials in `backend/.env` do not match the
+server. Verify with
+`psql -U "$DATABASE_USER" -h "$DATABASE_HOST" -d "$DATABASE_NAME" -c "SELECT 1;"`.
+
+### `database "mindblock" does not exist`
+
+Create it: `createdb mindblock`.
+
+### `EADDRINUSE: address already in use :::3000`
+
+Something already holds port 3000, usually a previous backend process or the
+frontend dev server.
+
+```bash
+# macOS / Linux
+lsof -ti:3000 | xargs kill
+
+# Windows (PowerShell)
+Get-NetTCPConnection -LocalPort 3000 | Select-Object -ExpandProperty OwningProcess | ForEach-Object { Stop-Process -Id $_ }
+```
+
+### `401 Unauthorized` on every backend request
+
+Most routes sit behind the JWT middleware. Only `/auth/*`, `/api`, `/docs`, and
+`/health` are public. Sign in first and send
+`Authorization: Bearer <accessToken>`.
+
+### `400 Bad Request` with `property ... should not exist`
+
+The global `ValidationPipe` runs with `forbidNonWhitelisted: true`, so any field
+not declared on the DTO is rejected. Remove the extra field or add it to the DTO.
+
+### `ERROR: Absolute imports from "src/" are not allowed`
+
+The `lint-imports` CI job rejects `from "src/..."`. Use relative imports
+(`../../components/X`). See [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+### Frontend build fails with an unsupported Node version
+
+Next.js 16 needs Node >= 20.9. Run `nvm use 20`, delete `frontend/.next`, and
+rebuild.
+
+### `npm ci` fails after switching branches
+
+The lockfile changed. Remove stale installs and retry:
+
+```bash
+rm -rf node_modules backend/node_modules frontend/node_modules
+npm ci
+```
+
+### Contract build fails resolving `ed25519-dalek`
+
+`contract/Cargo.toml` pins `ed25519-dalek = "=2.2.0"` on purpose. Build with
+`--locked` and do not upgrade that pin without reading the comment above it.
+
+---
+
+## 13. Contributor workflow
+
+1. Pick or open an issue and comment that you are taking it.
+2. Fork, then branch from `main`: `feature/...`, `fix/<issue-number>`, `chore/...`, or `docs/...`.
+3. Make the change, keeping it scoped to the issue.
+4. Run the tests, lint, type-check, and build commands from section 11.
+5. Commit using Conventional Commits: `feat(auth): add refresh token rotation`.
+6. Push and open a pull request with problem, solution, acceptance criteria, and testing notes, and link the issue with `closes #<number>`.
+7. Address review feedback with follow-up commits; keep the branch up to date with `main`.
+
+The full standard, including PR title validation and branch protection, is in
+[CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,235 @@
+# Environment Variables
+
+Every variable used by the Mind Block monorepo, where it is read from, and what
+it does. Copy the templates in each section into the matching env file before
+starting a service.
+
+| Package  | Env file location     | Loaded by |
+| -------- | --------------------- | --------- |
+| Backend  | `backend/.env`        | `@nestjs/config` (`ConfigModule.forRoot({ envFilePath: ['.env'] })` in `backend/src/app.module.ts`) |
+| Frontend | `frontend/.env.local` | Next.js built-in env loading |
+| Contract | shell environment     | Stellar CLI (`stellar`) |
+
+Env files are git-ignored. Never commit real secrets; `backend/.env.example` is
+the tracked template.
+
+---
+
+## 1. Backend (`backend/.env`)
+
+### 1.1 Runtime
+
+| Variable | Required | Default | Description |
+| -------- | -------- | ------- | ----------- |
+| `NODE_ENV` | No | `development` | Runtime mode. `npm run start:dev` sets it to `development` for you. Read in `backend/src/config/app.config.ts`. |
+| `API_VERSION` | No | unset | Free-form version string surfaced through `appConfig`. |
+
+The HTTP port is currently hard-coded to `3000` in `backend/src/main.ts`
+(`await app.listen(3000)`); there is no `PORT` variable yet.
+
+### 1.2 PostgreSQL
+
+The backend supports two mutually exclusive shapes. If `DATABASE_URL` is set it
+wins and the discrete variables are ignored (see the TypeORM factory in
+`backend/src/app.module.ts`).
+
+| Variable | Required | Default | Description |
+| -------- | -------- | ------- | ----------- |
+| `DATABASE_URL` | Production only | unset | Full connection string, for example `postgres://user:pass@host:5432/mindblock`. Used by managed hosts such as Render. |
+| `DATABASE_HOST` | Yes (local) | `localhost` | PostgreSQL host. |
+| `DATABASE_PORT` | Yes (local) | `5432` | PostgreSQL port. |
+| `DATABASE_USER` | Yes (local) | unset | Database user. |
+| `DATABASE_PASSWORD` | Yes (local) | unset | Database password. |
+| `DATABASE_NAME` | Yes (local) | unset | Database name, for example `mindblock`. |
+| `DATABASE_SYNC` | No | `false` | `true` lets TypeORM auto-create the schema from entities. Convenient locally, never use it against shared or production data. |
+| `DATABASE_LOAD` | No | `false` | `true` enables `autoLoadEntities`, so entities registered through `TypeOrmModule.forFeature` are picked up automatically. Keep this on locally. |
+
+> Known quirk: `backend/src/config/database.config.ts` maps those two flags to
+> the strings `"true"` and `"false"`, and any non-empty string is truthy. In
+> practice TypeORM therefore behaves as if both are enabled whatever you set.
+> Treat `DATABASE_SYNC` as always on for local work and point the backend at a
+> throwaway database.
+
+### 1.3 TypeORM CLI (migrations only)
+
+`backend/data-source.ts` is a standalone `DataSource` used by the TypeORM CLI.
+It reads a different, `DB_`-prefixed set of variables from the ones the Nest
+application uses, so set both groups when you intend to run migrations.
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `DB_HOST` | `localhost` | Host for the CLI data source. |
+| `DB_PORT` | `5432` | Port for the CLI data source. |
+| `DB_USERNAME` | `your_username` | User for the CLI data source. |
+| `DB_PASSWORD` | `your_password` | Password for the CLI data source. |
+| `DB_NAME` | `your_database` | Database for the CLI data source. |
+
+See [DEVELOPMENT.md](./DEVELOPMENT.md#9-migrations) for how migrations are run
+today and the caveats around this file.
+
+### 1.4 Redis
+
+| Variable | Required | Default | Description |
+| -------- | -------- | ------- | ----------- |
+| `REDIS_URL` | Yes | none | Connection URL for `ioredis`, for example `redis://127.0.0.1:6379`. `backend/src/redis/redis.provider.ts` throws `REDIS_URL not defined in environment variables` at boot when it is missing, so the backend will not start without it. |
+
+Redis backs the JWT session and blacklist lookups used by the auth middleware,
+plus caching across the app.
+
+### 1.5 Authentication (JWT)
+
+Read in `backend/src/auth/authConfig/jwt.config.ts`.
+
+| Variable | Required | Default | Description |
+| -------- | -------- | ------- | ----------- |
+| `JWT_SECRET` | Yes | none | Signing secret for access and refresh tokens. Use at least 32 characters; generate one with `openssl rand -base64 48`. |
+| `JWT_TOKEN_AUDIENCE` | No | `localhost` | `aud` claim. Locally `localhost:3000`. |
+| `JWT_TOKEN_ISSUER` | No | `localhost` | `iss` claim. Locally `localhost:3000`. |
+| `JWT_ACCESS_TOKEN_TTL` | No | `3600` | Access-token lifetime in seconds. |
+
+### 1.6 Google OAuth
+
+| Variable | Required | Description |
+| -------- | -------- | ----------- |
+| `GOOGLE_CLIENT_ID` | Google sign-in only | OAuth 2.0 client ID from the Google Cloud console. |
+| `GOOGLE_CLIENT_SECRET` | Google sign-in only | OAuth 2.0 client secret. |
+| `GOOGLE_CALLBACK_URL` and `GOOGLE_REDIRECT_URI` | Google sign-in only | Redirect URI registered with Google. Both names appear in the codebase; set them to the same value. |
+
+Google sign-in is optional for local development. Leave these unset and use
+email/password or Stellar wallet login instead.
+
+### 1.7 Mail (SMTP)
+
+| Variable | Required | Default | Description |
+| -------- | -------- | ------- | ----------- |
+| `MAIL_HOST` | Mail features only | unset | SMTP host, for example `smtp.gmail.com`. |
+| `SMTP_PORT` | No | `2525` | SMTP port read by `appConfig`. `backend/.env.example` also lists `MAIL_PORT`, but `SMTP_PORT` is the name the config actually reads. |
+| `SMTP_USERNAME` | Mail features only | unset | SMTP username. |
+| `SMTP_PASSWORD` | Mail features only | unset | SMTP password or app password. |
+| `MAIL_SECURE` | No | `false` | `true` to use TLS on connect. |
+| `MAIL_FROM_NAME` | No | unset | Display name on outbound mail. |
+| `MAIL_FROM_ADDRESS` | No | unset | From address on outbound mail. |
+
+Password reset (`POST /auth/forgot-password`) is the main mail-dependent flow.
+Use a throwaway inbox such as Mailtrap locally.
+
+### 1.8 Operations
+
+| Variable | Required | Default | Description |
+| -------- | -------- | ------- | ----------- |
+| `ADMIN_HEALTH_KEY` | No | `admin-key` | Value expected in the `x-admin-key` header by `GET /health/detailed`. Always override it outside local development. |
+
+### 1.9 Backend template
+
+```dotenv
+# Runtime
+NODE_ENV=development
+
+# PostgreSQL (local)
+DATABASE_HOST=localhost
+DATABASE_PORT=5432
+DATABASE_USER=postgres
+DATABASE_PASSWORD=password
+DATABASE_NAME=mindblock
+DATABASE_SYNC=true
+DATABASE_LOAD=true
+
+# TypeORM CLI data source (migrations)
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=password
+DB_NAME=mindblock
+
+# Redis
+REDIS_URL=redis://127.0.0.1:6379
+
+# JWT
+JWT_SECRET=change-me-to-at-least-32-random-characters
+JWT_TOKEN_AUDIENCE=localhost:3000
+JWT_TOKEN_ISSUER=localhost:3000
+JWT_ACCESS_TOKEN_TTL=3600
+
+# Google OAuth (optional locally)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google-authentication
+GOOGLE_REDIRECT_URI=http://localhost:3000/auth/google-authentication
+
+# Mail (optional locally)
+MAIL_HOST=smtp.mailtrap.io
+SMTP_PORT=2525
+SMTP_USERNAME=
+SMTP_PASSWORD=
+MAIL_SECURE=false
+MAIL_FROM_NAME=MindBlock
+MAIL_FROM_ADDRESS=noreply@mindblock.com
+
+# Operations
+ADMIN_HEALTH_KEY=local-admin-key
+```
+
+---
+
+## 2. Frontend (`frontend/.env.local`)
+
+Only variables prefixed with `NEXT_PUBLIC_` reach the browser. Anything you put
+here is public, so never place secrets in the frontend env file.
+
+| Variable | Required | Default | Description |
+| -------- | -------- | ------- | ----------- |
+| `NEXT_PUBLIC_API_URL` | Yes | unset | Base URL of the backend API. Locally `http://localhost:3000`. In production it points at the deployed backend. |
+| `NODE_ENV` | No | set by Next.js | Managed by `next dev` and `next build`; do not set it manually. |
+
+```dotenv
+NEXT_PUBLIC_API_URL=http://localhost:3000
+```
+
+> The Stellar auth helper in `frontend/lib/stellar/api.ts` still hard-codes
+> `http://localhost:3000`. If you move the backend to another host or port, that
+> module needs updating too; it does not read `NEXT_PUBLIC_API_URL` yet.
+
+---
+
+## 3. Stellar and Soroban (shell environment)
+
+The contract in `contract/` is built and deployed with the Stellar CLI, which
+reads its configuration from CLI flags and your shell rather than from an env
+file in this repo. None of this is required to run the backend or frontend
+locally.
+
+| Variable | Required | Example | Description |
+| -------- | -------- | ------- | ----------- |
+| `STELLAR_NETWORK` | Deploys | `testnet` | Network alias used by `stellar contract deploy --network`. |
+| `STELLAR_RPC_URL` | Deploys | `https://soroban-testnet.stellar.org` | Soroban RPC endpoint. |
+| `STELLAR_NETWORK_PASSPHRASE` | Deploys | `Test SDF Network ; September 2015` | Network passphrase matching the RPC endpoint. |
+| `STELLAR_ACCOUNT` | Deploys | `deployer` | Identity alias created with `stellar keys generate`. |
+| `STELLAR_SECRET_KEY` | Deploys | `S...` | Raw secret seed, only if you are not using a named identity. Keep it out of the repo and out of shell history. |
+
+Configure a testnet identity once:
+
+```bash
+stellar keys generate deployer --network testnet --fund
+stellar network add testnet \
+  --rpc-url https://soroban-testnet.stellar.org \
+  --network-passphrase "Test SDF Network ; September 2015"
+```
+
+Client-side wallet interaction on the frontend goes through
+`@stellar/freighter-api` and the browser extension, so it needs no variables:
+the user's wallet supplies the network and the keys.
+
+`shared/config/networks.ts` still holds legacy Starknet endpoints and is not
+part of the Stellar configuration path.
+
+---
+
+## 4. Checklist before your first run
+
+- [ ] `backend/.env` exists and contains `REDIS_URL`, `JWT_SECRET`, and the `DATABASE_*` block.
+- [ ] PostgreSQL is reachable at `DATABASE_HOST:DATABASE_PORT` and the database named in `DATABASE_NAME` exists.
+- [ ] Redis answers `redis-cli ping` with `PONG`.
+- [ ] `frontend/.env.local` contains `NEXT_PUBLIC_API_URL=http://localhost:3000`.
+
+Troubleshooting for each of these lives in
+[DEVELOPMENT.md](./DEVELOPMENT.md#12-common-errors).

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,234 @@
+# Testing, Linting, and Builds
+
+What the repo can verify today, how to run each check locally, and what CI
+enforces on every pull request.
+
+---
+
+## 1. What exists
+
+| Package | Framework | Location | State |
+| ------- | --------- | -------- | ----- |
+| Backend | Jest + ts-jest | `backend/src/**/*.spec.ts` | Unit and integration specs across auth, health, analytics, quests, streaks, and more. |
+| Backend (e2e) | Jest + Supertest | `backend/test/*.e2e-spec.ts` | `app.e2e-spec.ts` and `analytics.e2e-spec.ts`. |
+| Frontend | none configured | `frontend/components/ui/__tests__/*.test.tsx` | Test files exist, but the frontend has no test runner in `package.json` yet, so there is no `npm test` for it. |
+| Contract | Rust `cargo test` | `contract/src` | Run from `contract/`. |
+
+Wiring a runner into the frontend workspace is an open, welcome contribution.
+
+---
+
+## 2. Backend tests
+
+Run from `backend/`, or from the repo root with `--workspace backend`.
+
+| Command | What it does |
+| ------- | ------------ |
+| `npm run test` | All `*.spec.ts` files. |
+| `npm run test:watch` | Re-run on change. |
+| `npm run test:cov` | Coverage report into `backend/coverage/`. |
+| `npm run test:e2e` | End-to-end specs via `test/jest-e2e.json`. |
+| `npm run test:debug` | Serial run with the Node inspector attached. |
+
+```bash
+# From the repo root
+npm --workspace backend run test
+npm --workspace backend run test:cov
+npm --workspace backend run test:e2e
+```
+
+Narrow the run while iterating:
+
+```bash
+cd backend
+npm run test -- health                     # by path or name fragment
+npm run test -- src/streak/streaks.service.spec.ts
+npm run test -- -t "returns the current streak"   # by test title
+```
+
+Jest configuration lives in `backend/jest.config.js`: `ts-jest`, a `node`
+environment, `testRegex: '.*\\.spec\\.ts$'`, and a `^src/(.*)$` module alias.
+E2E configuration is `backend/test/jest-e2e.json` with
+`testRegex: '.e2e-spec.ts$'`.
+
+### Do the tests need PostgreSQL and Redis?
+
+Unit specs mock their dependencies and run without infrastructure. E2E specs
+boot the Nest application, so they need whatever the imported modules need:
+start PostgreSQL and Redis, and make sure `backend/.env` is populated, before
+running `test:e2e`. See [DEVELOPMENT.md](./DEVELOPMENT.md).
+
+### Writing a test
+
+Place the spec next to the code as `<name>.spec.ts` and build the module with
+`@nestjs/testing`:
+
+```ts
+import { Test } from '@nestjs/testing';
+import { StreaksService } from './providers/streaks.service';
+
+describe('StreaksService', () => {
+  let service: StreaksService;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        StreaksService,
+        { provide: 'StreakRepository', useValue: { findOne: jest.fn() } },
+      ],
+    }).compile();
+
+    service = moduleRef.get(StreaksService);
+  });
+
+  it('is defined', () => {
+    expect(service).toBeDefined();
+  });
+});
+```
+
+Guidelines:
+
+- Use relative imports; the `lint-imports` CI job rejects `from "src/..."`.
+- Mock repositories and external services rather than reaching for a real database in unit specs.
+- Cover the failure paths, not just the happy path. Most bugs found in review are unhandled `null`s and off-by-one boundaries.
+- Reserve e2e specs for real request and response contracts.
+
+---
+
+## 3. Contract tests
+
+```bash
+cd contract
+cargo test --locked
+```
+
+CI also runs `cargo fmt --all -- --check` and
+`cargo clippy --locked --all-targets --all-features -- -D warnings`, both of
+which fail the build on any warning.
+
+---
+
+## 4. Lint
+
+```bash
+npm --workspace backend run lint     # ESLint + Prettier, applies --fix
+npm --workspace frontend run lint    # eslint-config-next
+```
+
+Formatting only, backend:
+
+```bash
+npm --workspace backend run format
+```
+
+The backend lint script runs with `--fix`, so review the diff it produces before
+committing.
+
+### Import rule
+
+Absolute `src/...` imports are rejected by the `lint-imports` job:
+
+```ts
+// Not allowed
+import X from 'src/components/X';
+
+// Correct
+import X from '../../components/X';
+```
+
+Check it locally the same way CI does:
+
+```bash
+grep -RIn --include='*.ts' --include='*.tsx' --exclude-dir=node_modules \
+  -E "^[[:space:]]*(import|export)[^;]*from[[:space:]]+['\"]src/" .
+```
+
+No output means you are clean.
+
+---
+
+## 5. Type-check
+
+```bash
+npm --workspace backend exec -- tsc --noEmit -p tsconfig.json
+npm --workspace frontend exec -- tsc --noEmit -p tsconfig.json
+```
+
+---
+
+## 6. Build
+
+```bash
+npm --workspace backend run build     # tsc -p tsconfig.build.json -> dist/
+npm --workspace frontend run build    # next build
+```
+
+Both must pass before a pull request is mergeable.
+
+---
+
+## 7. The full pre-PR check
+
+Run this from the repo root; it mirrors what CI does:
+
+```bash
+npm ci
+
+npm --workspace backend run lint
+npm --workspace frontend run lint
+
+npm --workspace backend exec -- tsc --noEmit -p tsconfig.json
+npm --workspace frontend exec -- tsc --noEmit -p tsconfig.json
+
+npm --workspace backend run test
+
+npm --workspace backend run build
+npm --workspace frontend run build
+
+# Only if you touched contract/
+cd contract && cargo fmt --all -- --check \
+  && cargo clippy --locked --all-targets --all-features -- -D warnings \
+  && cargo test --locked
+```
+
+---
+
+## 8. What CI runs
+
+Two workflows live in `.github/workflows/`.
+
+### `ci.yml` (push and pull requests to `main` and `develop`)
+
+| Job | Checks |
+| --- | ------ |
+| `lint-imports` | No absolute `src/...` imports anywhere in the repo. |
+| `build` | Node 20.x, `npm ci`, frontend and backend builds. |
+| `type-check` | `tsc --noEmit` for both workspaces. |
+| `contracts` | `cargo fmt --check`, `clippy -D warnings`, wasm release build, `cargo test`. |
+
+### `ci-cd.yml` (pull requests)
+
+| Job | Checks |
+| --- | ------ |
+| `validate-pr` | PR title matches Conventional Commits (`feat`, `fix`, `docs`, `chore`, `test`, `refactor`, `ci`) and the description is at least 20 characters. |
+| `build-and-deploy` | Runs only after `validate-pr` passes: installs, builds both workspaces, then builds the contract for `wasm32-unknown-unknown`. |
+
+`main` and `develop` are protected: `lint-imports`, `build`, `type-check`, and
+`contracts` must be green and the branch must be up to date before merge.
+
+---
+
+## 9. Debugging failures
+
+| Symptom | Likely cause and fix |
+| ------- | -------------------- |
+| Tests hang and never exit | An open handle, usually a Redis or TypeORM connection left open. Close it in `afterAll`, or run with `--detectOpenHandles`. |
+| `Cannot find module 'src/...'` | Use a relative import. The alias exists in Jest config but is banned by `lint-imports`. |
+| E2E specs fail on connection errors | PostgreSQL or Redis is not running, or `backend/.env` is incomplete. |
+| `Nest can't resolve dependencies of X` | A provider is missing from the testing module. Add it, or supply a mock with `{ provide: TOKEN, useValue: mock }`. |
+| Local pass, CI failure | Check your Node version (`node -v`, expected 20.x) and re-run with `npm ci` rather than `npm install`. |
+| `clippy` fails but the code compiles | CI runs clippy with `-D warnings`; every warning is an error there. |
+
+More setup-level troubleshooting is in
+[DEVELOPMENT.md](./DEVELOPMENT.md#12-common-errors).


### PR DESCRIPTION
## Problem

The root README documented a setup flow that no longer matches the repository. It pointed at a contracts/ directory that does not exist, listed only three backend environment variables, gave no Node or package-manager requirement, and said nothing about PostgreSQL, Redis, migrations, seed data, or how to run the test suite. There was no API reference outside the generated Swagger page, no environment reference, and no architecture overview. A new contributor could not get from clone to a running stack with passing tests without asking a maintainer.

## Solution

Added a contributor-oriented documentation set under docs/ and rewrote the root README and CONTRIBUTING to point at it. Every command, variable, path, and default below was read out of the codebase rather than assumed.

### New files

**docs/API.md** - REST reference for the NestJS backend: base URLs and the Swagger mount point, the bearer-token model and the exact public prefixes excluded from JwtAuthMiddleware (auth, api, docs, health), validation semantics under forbidNonWhitelisted, the error-status table, throttling, pagination defaults, and CORS. Then every route grouped by area (auth, health, users, puzzles, categories, game sessions, challenge attempts, progress, daily quest, streaks, analytics, blockchain, admin), with request bodies taken from the DTOs, real enum values for PuzzleDifficulty and GameSessionStatus, and a three-step Stellar wallet login walkthrough.

**docs/ENVIRONMENT.md** - Every environment variable in the repo, grouped by concern, each with required/default/description and the file that reads it. Covers the backend runtime, PostgreSQL including DATABASE_URL taking priority over the discrete variables, the separate DB-prefixed set that data-source.ts uses for the TypeORM CLI, Redis, JWT, Google OAuth, SMTP, and ADMIN_HEALTH_KEY; then the frontend variable and the Stellar CLI shell variables needed for deploys. Includes copy-paste templates for the backend and frontend env files and a pre-flight checklist.

**docs/DEVELOPMENT.md** - The clone to install to configure to PostgreSQL to Redis to backend to frontend to tests path, in order, with Docker and native options for both datastores. Documents prerequisites with versions, npm workspaces usage, every backend and frontend script, the contract toolchain, the current state of migrations and seed data, and a common-errors section covering the missing REDIS_URL boot failure, connection refusals on 5432 and 6379, port 3000 already in use, blanket 401s from the global JWT middleware, the property-should-not-exist rejection from the validation pipe, the absolute-import CI rejection, Node version mismatches, and the ed25519-dalek pin.

**docs/ARCHITECTURE.md** - Component diagram, annotated repository layout, the backend module/controller/provider layering, the full request lifecycle from correlation ID through to the exception filter, a cross-cutting-concerns table covering config, persistence, caching, auth, authorization, rate limiting, scheduling, events, docs, and shutdown, the domain flow of a play-through, frontend stack, contract notes, data stores, and deployment targets.

**docs/TESTING.md** - What is testable today per package, every backend Jest command with narrowing examples, whether infrastructure is needed for unit versus e2e specs, a spec template, contract checks, lint, type-check, build, the full pre-PR sequence, an exact breakdown of both CI workflows and their job names, and a failure-debugging table.

### Updated files

**README.md** - Kept the product introduction and hosting section; replaced the setup section with a prerequisites table (Node 20.x LTS 20.9 or newer, npm 10.x, PostgreSQL 14 or newer, Redis 6 or newer) and a numbered clone to install to configure to database to Redis to backend to frontend to tests path that matches the acceptance criteria. Added a documentation index, a common-commands table, and a troubleshooting pointer. Corrected the contracts/ references to contract/ and replaced the non-existent Stellar build commands.

**CONTRIBUTING.md** - Added a before-you-start routing table, an explicit ten-step contributor workflow, a code-standards section covering the DTO contract, Swagger annotations, documenting new environment variables, and secrets, a documentation-changes policy, and docs branch naming. Kept the existing import rule, local checks, branch protection, and PR standards intact, correcting the contract directory name and aligning the contract checks with what CI actually runs.

### Accuracy notes

Where the code and the ideal state differ, the docs describe reality and flag the gap rather than documenting something that does not work:

- backend/data-source.ts reads DB-prefixed variables while the app reads DATABASE-prefixed ones, its migrations glob resolves to backend/migrations/ while the files live in backend/src/database/migrations/, and its entities glob is missing a path separator.
- DATABASE_SYNC and DATABASE_LOAD are mapped to the strings true and false in database.config.ts, so both read as truthy whatever you set.
- backend/src/seed.ts is a scaffold with no seeders wired in and no npm script.
- The root dev script calls concurrently, which is not declared in any package.json and is absent from the lockfile.
- frontend/lib/stellar/api.ts hard-codes the localhost backend URL instead of reading NEXT_PUBLIC_API_URL.
- The frontend has test files but no configured test runner.
- The root workspaces array lists contracts and middleware, neither of which exists.

Each is called out as a known gap with a workaround, and several are noted as good follow-up PRs. This change is documentation only; no source or configuration files were touched.

## Acceptance Criteria

- [x] docs/API.md, docs/ENVIRONMENT.md, docs/DEVELOPMENT.md, docs/ARCHITECTURE.md, and docs/TESTING.md all exist
- [x] README.md and CONTRIBUTING.md updated and cross-linked to the new set
- [x] Required Node version and package manager documented
- [x] PostgreSQL and Redis setup documented, with Docker and native options
- [x] Backend, frontend, and Stellar environment variables documented
- [x] Migrations and seed data documented, including current limitations
- [x] Test, lint, and build commands documented for every package
- [x] Common errors documented with causes and fixes
- [x] Contributor workflow documented end to end
- [x] A new contributor can go from clone to install to configure to database to Redis to backend to frontend to tests using only committed instructions

## Testing Notes

- Every documented command was cross-checked against the scripts blocks in the root, backend, and frontend package.json files; commands that do not work as written, such as the root dev script, are flagged rather than listed as working.
- Environment variables were enumerated by grepping for process.env across backend/src, backend/data-source.ts, backend/scripts, and the frontend, then traced to the config file that reads each one.
- The endpoint tables were built from the Controller and HTTP-method decorators in every controller, with payload fields read from the corresponding DTO classes and enum values read from the enum definitions.
- CI job names, Node version, and the exact check commands were taken from the two workflow files in .github/workflows.
- All relative links and heading anchors between the new documents were verified to resolve.
- Documentation only, so no code paths change; existing lint, type-check, build, and test behaviour is unaffected.

closes #627
