### PR TITLE
feat: implement single-player session completion experience (#618)

### DIFF
--- a/backend/src/database/migrations/20260820000000-AddGameSessionCompletionSummary.ts
+++ b/backend/src/database/migrations/20260820000000-AddGameSessionCompletionSummary.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddGameSessionCompletionSummary20260820000000
+  implements MigrationInterface
+{
+  name = 'AddGameSessionCompletionSummary20260820000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      -- Server-calculated completion summary fields for game_sessions
+      ALTER TABLE "game_sessions"
+        ADD COLUMN IF NOT EXISTS "accuracy" integer,
+        ADD COLUMN IF NOT EXISTS "time_spent_seconds" integer,
+        ADD COLUMN IF NOT EXISTS "category_performance" jsonb,
+        ADD COLUMN IF NOT EXISTS "previous_streak" integer,
+        ADD COLUMN IF NOT EXISTS "current_streak" integer,
+        ADD COLUMN IF NOT EXISTS "reward_eligible" boolean,
+        ADD COLUMN IF NOT EXISTS "reward_reason" varchar(255);
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "game_sessions"
+        DROP COLUMN IF EXISTS "accuracy",
+        DROP COLUMN IF EXISTS "time_spent_seconds",
+        DROP COLUMN IF EXISTS "category_performance",
+        DROP COLUMN IF EXISTS "previous_streak",
+        DROP COLUMN IF EXISTS "current_streak",
+        DROP COLUMN IF EXISTS "reward_eligible",
+        DROP COLUMN IF EXISTS "reward_reason";
+    `);
+  }
+}

--- a/backend/src/game-sessions/dtos/game-session-response.dto.ts
+++ b/backend/src/game-sessions/dtos/game-session-response.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { GameSessionStatus } from '../enums/game-session-status.enum';
 import { PuzzleDifficulty } from '../../puzzles/enums/puzzle-difficulty.enum';
+import { CategoryPerformanceEntry } from '../interfaces/game-session.interface';
 
 export class GameSessionResponseDto {
   @ApiProperty({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' })
@@ -48,4 +49,36 @@ export class GameSessionResponseDto {
 
   @ApiProperty({ example: '2026-08-19T12:00:00.000Z' })
   updatedAt: Date;
+
+  @ApiPropertyOptional({
+    example: 80,
+    nullable: true,
+    description: 'Percentage of completed challenges answered correctly',
+  })
+  accuracy: number | null;
+
+  @ApiPropertyOptional({ example: 320, nullable: true })
+  timeSpentSeconds: number | null;
+
+  @ApiPropertyOptional({
+    type: 'array',
+    nullable: true,
+    description: 'Per-category correct/total breakdown for this session',
+  })
+  categoryPerformance: CategoryPerformanceEntry[] | null;
+
+  @ApiPropertyOptional({ example: 4, nullable: true })
+  previousStreak: number | null;
+
+  @ApiPropertyOptional({ example: 5, nullable: true })
+  currentStreak: number | null;
+
+  @ApiPropertyOptional({ example: true, nullable: true })
+  rewardEligible: boolean | null;
+
+  @ApiPropertyOptional({
+    example: 'Player meets reward eligibility requirements',
+    nullable: true,
+  })
+  rewardReason: string | null;
 }

--- a/backend/src/game-sessions/dtos/update-game-session-status.dto.ts
+++ b/backend/src/game-sessions/dtos/update-game-session-status.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEnum, IsInt, IsOptional, Min } from 'class-validator';
+import { IsEnum, IsInt, IsOptional, IsString, Min } from 'class-validator';
 import { GameSessionStatus } from '../enums/game-session-status.enum';
 
 export class UpdateGameSessionStatusDto {
@@ -12,11 +12,14 @@ export class UpdateGameSessionStatusDto {
   status: GameSessionStatus;
 
   /**
-   * When completing a session, optionally supply the final score and XP.
-   * The service will ignore these values for non-terminal transitions.
+   * Fallback score, only used when completing a session that has no
+   * tracked ChallengeAttempt records. Whenever attempts exist, the final
+   * score is calculated server-side from those records and this value
+   * is ignored.
    */
   @ApiPropertyOptional({
-    description: 'Final score (used when transitioning to COMPLETED)',
+    description:
+      'Fallback score used only when the session has no tracked challenge attempts',
     example: 850,
     minimum: 0,
   })
@@ -25,8 +28,13 @@ export class UpdateGameSessionStatusDto {
   @Min(0)
   score?: number;
 
+  /**
+   * Fallback XP, only used when completing a session that has no tracked
+   * ChallengeAttempt records. See `score` above.
+   */
   @ApiPropertyOptional({
-    description: 'XP earned (used when transitioning to COMPLETED)',
+    description:
+      'Fallback XP used only when the session has no tracked challenge attempts',
     example: 120,
     minimum: 0,
   })
@@ -34,4 +42,17 @@ export class UpdateGameSessionStatusDto {
   @IsInt()
   @Min(0)
   xpEarned?: number;
+
+  /**
+   * IANA timezone (e.g. "America/New_York") used to evaluate streak
+   * continuity when completing a session. Defaults to UTC if omitted.
+   */
+  @ApiPropertyOptional({
+    description:
+      'IANA timezone used for streak calculation on completion, defaults to UTC',
+    example: 'America/New_York',
+  })
+  @IsOptional()
+  @IsString()
+  userTimezone?: string;
 }

--- a/backend/src/game-sessions/entities/game-session.entity.ts
+++ b/backend/src/game-sessions/entities/game-session.entity.ts
@@ -11,6 +11,7 @@ import {
 import { GameSessionStatus } from '../enums/game-session-status.enum';
 import { PuzzleDifficulty } from '../../puzzles/enums/puzzle-difficulty.enum';
 import { User } from '../../users/user.entity';
+import { CategoryPerformanceEntry } from '../interfaces/game-session.interface';
 
 /**
  * GameSession represents a complete gameplay session for a user.
@@ -94,6 +95,41 @@ export class GameSession {
   /** Timestamp when the session reached a terminal state (COMPLETED / EXPIRED / ABANDONED). */
   @Column({ name: 'completed_at', type: 'timestamptz', nullable: true })
   completedAt: Date | null;
+
+  /**
+   * Percentage (0-100) of completed challenges answered correctly.
+   * Calculated server-side from ChallengeAttempt records at completion time.
+   */
+  @Column({ name: 'accuracy', type: 'int', nullable: true })
+  accuracy: number | null;
+
+  /** Total seconds spent across all challenge attempts in this session. */
+  @Column({ name: 'time_spent_seconds', type: 'int', nullable: true })
+  timeSpentSeconds: number | null;
+
+  /**
+   * Per-category breakdown of correct/total attempts, e.g.
+   * [{ categoryId, categoryName, correct, total, accuracy }].
+   * Calculated server-side and persisted so it survives a page refresh.
+   */
+  @Column({ name: 'category_performance', type: 'jsonb', nullable: true })
+  categoryPerformance: CategoryPerformanceEntry[] | null;
+
+  /** User's streak count immediately before this session completed. */
+  @Column({ name: 'previous_streak', type: 'int', nullable: true })
+  previousStreak: number | null;
+
+  /** User's streak count immediately after this session completed. */
+  @Column({ name: 'current_streak', type: 'int', nullable: true })
+  currentStreak: number | null;
+
+  /** Whether the player is eligible for a reward based on this session. */
+  @Column({ name: 'reward_eligible', type: 'boolean', nullable: true })
+  rewardEligible: boolean | null;
+
+  /** Human-readable reason for the reward eligibility outcome. */
+  @Column({ name: 'reward_reason', type: 'varchar', length: 255, nullable: true })
+  rewardReason: string | null;
 
   @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
   createdAt: Date;

--- a/backend/src/game-sessions/game-sessions.module.ts
+++ b/backend/src/game-sessions/game-sessions.module.ts
@@ -1,13 +1,22 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { GameSession } from './entities/game-session.entity';
+import { ChallengeAttempt } from '../challenge-attempt/entities/challenge-attempt.entity';
+import { Puzzle } from '../puzzles/entities/puzzle.entity';
 import { GameSessionsService } from './providers/game-sessions.service';
+import { SessionSummaryProvider } from './providers/session-summary.provider';
 import { GameSessionsController } from './controllers/game-sessions.controller';
+import { StreakModule } from '../streak/strerak.module';
+import { RewardsModule } from '../rewards/rewards.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([GameSession])],
+  imports: [
+    TypeOrmModule.forFeature([GameSession, ChallengeAttempt, Puzzle]),
+    StreakModule,
+    RewardsModule,
+  ],
   controllers: [GameSessionsController],
-  providers: [GameSessionsService],
+  providers: [GameSessionsService, SessionSummaryProvider],
   exports: [GameSessionsService],
 })
 export class GameSessionsModule {}

--- a/backend/src/game-sessions/interfaces/game-session.interface.ts
+++ b/backend/src/game-sessions/interfaces/game-session.interface.ts
@@ -43,3 +43,29 @@ export interface IGameSessionSummary {
   startedAt: Date | null;
   completedAt: Date | null;
 }
+
+/** Correct/total breakdown for a single puzzle category within a session. */
+export interface CategoryPerformanceEntry {
+  categoryId: string;
+  categoryName: string;
+  correct: number;
+  total: number;
+  accuracy: number;
+}
+
+/**
+ * Final statistics calculated server-side when a session is marked COMPLETED.
+ * Derived entirely from persisted ChallengeAttempt records for the session.
+ */
+export interface SessionCompletionStats {
+  totalScore: number;
+  xpEarned: number;
+  challengesCompleted: number;
+  accuracy: number;
+  timeSpentSeconds: number;
+  categoryPerformance: CategoryPerformanceEntry[];
+  previousStreak: number | null;
+  currentStreak: number | null;
+  rewardEligible: boolean | null;
+  rewardReason: string | null;
+}

--- a/backend/src/game-sessions/providers/game-sessions.service.spec.ts
+++ b/backend/src/game-sessions/providers/game-sessions.service.spec.ts
@@ -15,6 +15,8 @@ import { GameSessionStatus } from '../enums/game-session-status.enum';
 import { PuzzleDifficulty } from '../../puzzles/enums/puzzle-difficulty.enum';
 import { CreateGameSessionDto } from '../dtos/create-game-session.dto';
 import { UpdateGameSessionStatusDto } from '../dtos/update-game-session-status.dto';
+import { SessionSummaryProvider } from './session-summary.provider';
+import { SessionCompletionStats } from '../interfaces/game-session.interface';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Fixtures
@@ -37,6 +39,13 @@ function makeSession(overrides: Partial<GameSession> = {}): GameSession {
     completedAt: null,
     createdAt: new Date('2026-08-01T10:00:00Z'),
     updatedAt: new Date('2026-08-01T10:00:00Z'),
+    accuracy: null,
+    timeSpentSeconds: null,
+    categoryPerformance: null,
+    previousStreak: null,
+    currentStreak: null,
+    rewardEligible: null,
+    rewardReason: null,
     ...overrides,
   };
 }
@@ -45,9 +54,31 @@ function makeSession(overrides: Partial<GameSession> = {}): GameSession {
 // Suite
 // ─────────────────────────────────────────────────────────────────────────────
 
+/** Default stats stub: no tracked attempts, so completion falls back to
+ *  client-supplied score/xp — matches the pre-existing test fixtures below,
+ *  which don't set up any ChallengeAttempt records. */
+function makeStatsStub(
+  overrides: Partial<SessionCompletionStats> = {},
+): SessionCompletionStats {
+  return {
+    totalScore: 0,
+    xpEarned: 0,
+    challengesCompleted: 0,
+    accuracy: 0,
+    timeSpentSeconds: 0,
+    categoryPerformance: [],
+    previousStreak: null,
+    currentStreak: null,
+    rewardEligible: null,
+    rewardReason: null,
+    ...overrides,
+  };
+}
+
 describe('GameSessionsService', () => {
   let service: GameSessionsService;
   let repo: jest.Mocked<Repository<GameSession>>;
+  let summaryProvider: jest.Mocked<SessionSummaryProvider>;
 
   beforeEach(async () => {
     const mockRepo: Partial<jest.Mocked<Repository<GameSession>>> = {
@@ -58,6 +89,12 @@ describe('GameSessionsService', () => {
       createQueryBuilder: jest.fn(),
     };
 
+    const mockSummaryProvider: Partial<
+      jest.Mocked<SessionSummaryProvider>
+    > = {
+      buildCompletionStats: jest.fn().mockResolvedValue(makeStatsStub()),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GameSessionsService,
@@ -65,11 +102,16 @@ describe('GameSessionsService', () => {
           provide: getRepositoryToken(GameSession),
           useValue: mockRepo,
         },
+        {
+          provide: SessionSummaryProvider,
+          useValue: mockSummaryProvider,
+        },
       ],
     }).compile();
 
     service = module.get<GameSessionsService>(GameSessionsService);
     repo = module.get(getRepositoryToken(GameSession));
+    summaryProvider = module.get(SessionSummaryProvider);
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -329,13 +371,16 @@ describe('GameSessionsService', () => {
       expect(result.status).toBe(GameSessionStatus.PAUSED);
     });
 
-    it('transitions ACTIVE → COMPLETED, stamps completedAt and persists score/xp', async () => {
+    it('transitions ACTIVE → COMPLETED, stamps completedAt and falls back to client score/xp when no attempts are tracked', async () => {
       const session = makeSession({
         status: GameSessionStatus.ACTIVE,
         startedAt: new Date(),
       });
       repo.findOneBy.mockResolvedValue(session);
       repo.save.mockImplementation(async (s) => s as GameSession);
+      summaryProvider.buildCompletionStats.mockResolvedValue(
+        makeStatsStub({ challengesCompleted: 0 }),
+      );
 
       const dto: UpdateGameSessionStatusDto = {
         status: GameSessionStatus.COMPLETED,
@@ -352,6 +397,63 @@ describe('GameSessionsService', () => {
       expect(result.score).toBe(900);
       expect(result.xpEarned).toBe(200);
       expect(result.completedAt).toBeInstanceOf(Date);
+    });
+
+    it('ignores client-supplied score/xp and uses server-calculated stats when attempts are tracked', async () => {
+      const session = makeSession({
+        status: GameSessionStatus.ACTIVE,
+        startedAt: new Date(),
+      });
+      repo.findOneBy.mockResolvedValue(session);
+      repo.save.mockImplementation(async (s) => s as GameSession);
+      summaryProvider.buildCompletionStats.mockResolvedValue(
+        makeStatsStub({
+          totalScore: 640,
+          xpEarned: 640,
+          challengesCompleted: 5,
+          accuracy: 80,
+          timeSpentSeconds: 210,
+          categoryPerformance: [
+            {
+              categoryId: 'cat-1',
+              categoryName: 'Logic',
+              correct: 4,
+              total: 5,
+              accuracy: 80,
+            },
+          ],
+          previousStreak: 3,
+          currentStreak: 4,
+          rewardEligible: true,
+          rewardReason: 'Player meets reward eligibility requirements',
+        }),
+      );
+
+      const dto: UpdateGameSessionStatusDto = {
+        status: GameSessionStatus.COMPLETED,
+        // A malicious/stale client value that must be ignored.
+        score: 999999,
+        xpEarned: 999999,
+      };
+      const result = await service.updateStatus(
+        'session-uuid-1',
+        dto,
+        userId,
+      );
+
+      expect(summaryProvider.buildCompletionStats).toHaveBeenCalledWith(
+        'session-uuid-1',
+        session.userId,
+        undefined,
+      );
+      expect(result.score).toBe(640);
+      expect(result.xpEarned).toBe(640);
+      expect(result.accuracy).toBe(80);
+      expect(result.timeSpentSeconds).toBe(210);
+      expect(result.categoryPerformance).toHaveLength(1);
+      expect(result.previousStreak).toBe(3);
+      expect(result.currentStreak).toBe(4);
+      expect(result.rewardEligible).toBe(true);
     });
 
     it('transitions ACTIVE → ABANDONED and stamps completedAt', async () => {
@@ -426,13 +528,16 @@ describe('GameSessionsService', () => {
   // ───────────────────────────────────────────────────────────────────────────
 
   describe('completeSession()', () => {
-    it('delegates to updateStatus with COMPLETED status and supplied score/xp', async () => {
+    it('delegates to updateStatus with COMPLETED status and supplied score/xp as fallback', async () => {
       const session = makeSession({
         status: GameSessionStatus.ACTIVE,
         startedAt: new Date(),
       });
       repo.findOneBy.mockResolvedValue(session);
       repo.save.mockImplementation(async (s) => s as GameSession);
+      summaryProvider.buildCompletionStats.mockResolvedValue(
+        makeStatsStub({ challengesCompleted: 0 }),
+      );
 
       const result = await service.completeSession(
         'session-uuid-1',

--- a/backend/src/game-sessions/providers/game-sessions.service.ts
+++ b/backend/src/game-sessions/providers/game-sessions.service.ts
@@ -11,6 +11,7 @@ import { GameSessionStatus } from '../enums/game-session-status.enum';
 import { CreateGameSessionDto } from '../dtos/create-game-session.dto';
 import { UpdateGameSessionStatusDto } from '../dtos/update-game-session-status.dto';
 import { SessionTransitionMap } from '../interfaces/game-session.interface';
+import { SessionSummaryProvider } from './session-summary.provider';
 
 /**
  * Valid state transitions for a GameSession.
@@ -50,6 +51,7 @@ export class GameSessionsService {
   constructor(
     @InjectRepository(GameSession)
     private readonly sessionRepository: Repository<GameSession>,
+    private readonly sessionSummaryProvider: SessionSummaryProvider,
   ) {}
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -198,8 +200,29 @@ export class GameSessionsService {
     }
 
     if (dto.status === GameSessionStatus.COMPLETED) {
-      if (dto.score !== undefined) session.score = dto.score;
-      if (dto.xpEarned !== undefined) session.xpEarned = dto.xpEarned;
+      const stats = await this.sessionSummaryProvider.buildCompletionStats(
+        session.id,
+        session.userId,
+        dto.userTimezone,
+      );
+
+      // Statistics are calculated server-side from persisted challenge
+      // attempts. Client-supplied score/xpEarned are only used as a
+      // fallback when the session has no tracked attempts (e.g. legacy
+      // or externally-managed sessions), so completion never regresses
+      // to an unscored state.
+      const hasTrackedAttempts = stats.challengesCompleted > 0;
+      session.score = hasTrackedAttempts ? stats.totalScore : dto.score ?? 0;
+      session.xpEarned = hasTrackedAttempts
+        ? stats.xpEarned
+        : dto.xpEarned ?? 0;
+      session.accuracy = stats.accuracy;
+      session.timeSpentSeconds = stats.timeSpentSeconds;
+      session.categoryPerformance = stats.categoryPerformance;
+      session.previousStreak = stats.previousStreak;
+      session.currentStreak = stats.currentStreak;
+      session.rewardEligible = stats.rewardEligible;
+      session.rewardReason = stats.rewardReason;
     }
 
     session.status = dto.status;

--- a/backend/src/game-sessions/providers/session-summary.provider.spec.ts
+++ b/backend/src/game-sessions/providers/session-summary.provider.spec.ts
@@ -1,0 +1,171 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SessionSummaryProvider } from './session-summary.provider';
+import { ChallengeAttempt } from '../../challenge-attempt/entities/challenge-attempt.entity';
+import { AttemptStatus } from '../../challenge-attempt/enums/attempt-status.enum';
+import { Puzzle } from '../../puzzles/entities/puzzle.entity';
+import { StreaksService } from '../../streak/providers/streaks.service';
+import { RewardService } from '../../rewards/providers/reward.service';
+
+function makeAttempt(overrides: Partial<ChallengeAttempt> = {}): ChallengeAttempt {
+  return {
+    id: 'attempt-1',
+    sessionId: 'session-1',
+    userId: 'user-1',
+    challengeId: 'puzzle-1',
+    answer: 'answer',
+    status: AttemptStatus.CORRECT,
+    score: 100,
+    timeSpent: 30,
+    hintsUsed: 0,
+    solutionRevealed: false,
+    startedAt: new Date('2026-08-01T10:00:00Z'),
+    submittedAt: new Date('2026-08-01T10:00:30Z'),
+    ...overrides,
+  } as ChallengeAttempt;
+}
+
+function makePuzzle(overrides: Partial<Puzzle> = {}): Puzzle {
+  return {
+    id: 'puzzle-1',
+    categoryId: 'cat-1',
+    category: { id: 'cat-1', name: 'Logic' } as Puzzle['category'],
+    ...overrides,
+  } as Puzzle;
+}
+
+describe('SessionSummaryProvider', () => {
+  let provider: SessionSummaryProvider;
+  let attemptRepo: jest.Mocked<Repository<ChallengeAttempt>>;
+  let puzzleRepo: jest.Mocked<Repository<Puzzle>>;
+  let streaksService: jest.Mocked<StreaksService>;
+  let rewardService: jest.Mocked<RewardService>;
+
+  beforeEach(async () => {
+    const mockAttemptRepo: Partial<jest.Mocked<Repository<ChallengeAttempt>>> = {
+      find: jest.fn(),
+    };
+    const mockPuzzleRepo: Partial<jest.Mocked<Repository<Puzzle>>> = {
+      find: jest.fn(),
+    };
+    const mockStreaksService: Partial<jest.Mocked<StreaksService>> = {
+      getStreak: jest.fn(),
+      updateStreak: jest.fn(),
+    };
+    const mockRewardService: Partial<jest.Mocked<RewardService>> = {
+      checkEligibility: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SessionSummaryProvider,
+        { provide: getRepositoryToken(ChallengeAttempt), useValue: mockAttemptRepo },
+        { provide: getRepositoryToken(Puzzle), useValue: mockPuzzleRepo },
+        { provide: StreaksService, useValue: mockStreaksService },
+        { provide: RewardService, useValue: mockRewardService },
+      ],
+    }).compile();
+
+    provider = module.get(SessionSummaryProvider);
+    attemptRepo = module.get(getRepositoryToken(ChallengeAttempt));
+    puzzleRepo = module.get(getRepositoryToken(Puzzle));
+    streaksService = module.get(StreaksService);
+    rewardService = module.get(RewardService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns zeroed-out stats and skips streak/category lookups when there are no attempts', async () => {
+    attemptRepo.find.mockResolvedValue([]);
+    rewardService.checkEligibility.mockReturnValue({
+      eligible: false,
+      reason: 'Answer was incorrect',
+    });
+
+    const result = await provider.buildCompletionStats('session-1', 'user-1');
+
+    expect(result.challengesCompleted).toBe(0);
+    expect(result.totalScore).toBe(0);
+    expect(result.accuracy).toBe(0);
+    expect(result.categoryPerformance).toEqual([]);
+    expect(result.previousStreak).toBeNull();
+    expect(result.currentStreak).toBeNull();
+    expect(streaksService.getStreak).not.toHaveBeenCalled();
+    expect(puzzleRepo.find).not.toHaveBeenCalled();
+  });
+
+  it('aggregates score, accuracy, time spent and category breakdown from completed attempts', async () => {
+    attemptRepo.find.mockResolvedValue([
+      makeAttempt({ id: 'a1', status: AttemptStatus.CORRECT, score: 100, timeSpent: 20, challengeId: 'puzzle-1' }),
+      makeAttempt({ id: 'a2', status: AttemptStatus.INCORRECT, score: 0, timeSpent: 15, challengeId: 'puzzle-1' }),
+      makeAttempt({ id: 'a3', status: AttemptStatus.CORRECT, score: 80, timeSpent: 10, challengeId: 'puzzle-2' }),
+      // STARTED attempts (never submitted) are excluded from stats entirely.
+      makeAttempt({ id: 'a4', status: AttemptStatus.STARTED, score: 0, timeSpent: 0, challengeId: 'puzzle-2' }),
+    ]);
+    puzzleRepo.find.mockResolvedValue([
+      makePuzzle({ id: 'puzzle-1', categoryId: 'cat-1', category: { id: 'cat-1', name: 'Logic' } as Puzzle['category'] }),
+      makePuzzle({ id: 'puzzle-2', categoryId: 'cat-2', category: { id: 'cat-2', name: 'Coding' } as Puzzle['category'] }),
+    ]);
+    streaksService.getStreak.mockResolvedValue({ currentStreak: 3 } as never);
+    streaksService.updateStreak.mockResolvedValue({ currentStreak: 4 } as never);
+    rewardService.checkEligibility.mockReturnValue({
+      eligible: true,
+      reason: 'Player meets reward eligibility requirements',
+    });
+
+    const result = await provider.buildCompletionStats(
+      'session-1',
+      'user-1',
+      'America/New_York',
+    );
+
+    expect(result.challengesCompleted).toBe(3);
+    expect(result.totalScore).toBe(180);
+    expect(result.xpEarned).toBe(180);
+    expect(result.accuracy).toBe(67); // 2/3 correct, rounded
+    expect(result.timeSpentSeconds).toBe(45);
+
+    const logic = result.categoryPerformance.find((c) => c.categoryId === 'cat-1');
+    const coding = result.categoryPerformance.find((c) => c.categoryId === 'cat-2');
+    expect(logic).toEqual({
+      categoryId: 'cat-1',
+      categoryName: 'Logic',
+      correct: 1,
+      total: 2,
+      accuracy: 50,
+    });
+    expect(coding).toEqual({
+      categoryId: 'cat-2',
+      categoryName: 'Coding',
+      correct: 1,
+      total: 1,
+      accuracy: 100,
+    });
+
+    expect(streaksService.getStreak).toHaveBeenCalledWith('user-1');
+    expect(streaksService.updateStreak).toHaveBeenCalledWith(
+      'user-1',
+      'America/New_York',
+    );
+    expect(result.previousStreak).toBe(3);
+    expect(result.currentStreak).toBe(4);
+    expect(result.rewardEligible).toBe(true);
+  });
+
+  it('skips streak updates for guest sessions (no userId)', async () => {
+    attemptRepo.find.mockResolvedValue([makeAttempt()]);
+    puzzleRepo.find.mockResolvedValue([makePuzzle()]);
+    rewardService.checkEligibility.mockReturnValue({
+      eligible: true,
+      reason: 'Player meets reward eligibility requirements',
+    });
+
+    const result = await provider.buildCompletionStats('session-1', null);
+
+    expect(streaksService.getStreak).not.toHaveBeenCalled();
+    expect(streaksService.updateStreak).not.toHaveBeenCalled();
+    expect(result.previousStreak).toBeNull();
+    expect(result.currentStreak).toBeNull();
+  });
+});

--- a/backend/src/game-sessions/providers/session-summary.provider.ts
+++ b/backend/src/game-sessions/providers/session-summary.provider.ts
@@ -1,0 +1,184 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { ChallengeAttempt } from '../../challenge-attempt/entities/challenge-attempt.entity';
+import { AttemptStatus } from '../../challenge-attempt/enums/attempt-status.enum';
+import { Puzzle } from '../../puzzles/entities/puzzle.entity';
+import { StreaksService } from '../../streak/providers/streaks.service';
+import { RewardService } from '../../rewards/providers/reward.service';
+import {
+  CategoryPerformanceEntry,
+  SessionCompletionStats,
+} from '../interfaces/game-session.interface';
+
+/** Attempt statuses that count as "completed" for session statistics. */
+const COMPLETED_ATTEMPT_STATUSES = new Set<AttemptStatus>([
+  AttemptStatus.CORRECT,
+  AttemptStatus.INCORRECT,
+  AttemptStatus.EXPIRED,
+]);
+
+/**
+ * XP conversion ratio applied to the aggregated session score.
+ * No XP formula exists elsewhere in the codebase yet; this 1:1 ratio is a
+ * documented placeholder that can be tuned without touching call sites.
+ */
+const XP_PER_SCORE_POINT = 1;
+
+/** Default timezone used for streak calculation when the caller doesn't supply one. */
+const DEFAULT_STREAK_TIMEZONE = 'UTC';
+
+@Injectable()
+export class SessionSummaryProvider {
+  constructor(
+    @InjectRepository(ChallengeAttempt)
+    private readonly attemptRepository: Repository<ChallengeAttempt>,
+    @InjectRepository(Puzzle)
+    private readonly puzzleRepository: Repository<Puzzle>,
+    private readonly streaksService: StreaksService,
+    private readonly rewardService: RewardService,
+  ) {}
+
+  /**
+   * Builds the final completion statistics for a session.
+   *
+   * All numeric results (score, xp, accuracy, category breakdown) are
+   * derived from persisted ChallengeAttempt rows, not from client input.
+   * Streak updates are only applied for authenticated users (guests have
+   * no userId and therefore no streak).
+   */
+  async buildCompletionStats(
+    sessionId: string,
+    userId: string | null,
+    userTimezone: string = DEFAULT_STREAK_TIMEZONE,
+  ): Promise<SessionCompletionStats> {
+    const attempts = await this.attemptRepository.find({
+      where: { sessionId },
+      order: { startedAt: 'ASC' },
+    });
+
+    const completedAttempts = attempts.filter((attempt) =>
+      COMPLETED_ATTEMPT_STATUSES.has(attempt.status),
+    );
+
+    const totalScore = completedAttempts.reduce(
+      (sum, attempt) => sum + (attempt.score ?? 0),
+      0,
+    );
+    const timeSpentSeconds = completedAttempts.reduce(
+      (sum, attempt) => sum + (attempt.timeSpent ?? 0),
+      0,
+    );
+    const correctCount = completedAttempts.filter(
+      (attempt) => attempt.status === AttemptStatus.CORRECT,
+    ).length;
+    const challengesCompleted = completedAttempts.length;
+    const accuracy =
+      challengesCompleted > 0
+        ? Math.round((correctCount / challengesCompleted) * 100)
+        : 0;
+    const xpEarned = totalScore * XP_PER_SCORE_POINT;
+
+    const categoryPerformance = await this.buildCategoryPerformance(
+      completedAttempts,
+    );
+
+    const { previousStreak, currentStreak } = await this.applyStreakUpdate(
+      userId,
+      userTimezone,
+      challengesCompleted,
+    );
+
+    const rewardResult = this.rewardService.checkEligibility({
+      score: totalScore,
+      xp: xpEarned,
+      correct: correctCount > 0,
+    });
+
+    return {
+      totalScore,
+      xpEarned,
+      challengesCompleted,
+      accuracy,
+      timeSpentSeconds,
+      categoryPerformance,
+      previousStreak,
+      currentStreak,
+      rewardEligible: rewardResult.eligible,
+      rewardReason: rewardResult.reason,
+    };
+  }
+
+  /**
+   * Groups completed attempts by puzzle category and computes a
+   * correct/total/accuracy breakdown per category.
+   */
+  private async buildCategoryPerformance(
+    completedAttempts: ChallengeAttempt[],
+  ): Promise<CategoryPerformanceEntry[]> {
+    if (completedAttempts.length === 0) return [];
+
+    const challengeIds = [
+      ...new Set(completedAttempts.map((attempt) => attempt.challengeId)),
+    ];
+
+    const puzzles = await this.puzzleRepository.find({
+      where: { id: In(challengeIds) },
+      relations: ['category'],
+    });
+    const puzzleById = new Map(puzzles.map((puzzle) => [puzzle.id, puzzle]));
+
+    const byCategory = new Map<
+      string,
+      { categoryName: string; correct: number; total: number }
+    >();
+
+    for (const attempt of completedAttempts) {
+      const puzzle = puzzleById.get(attempt.challengeId);
+      const categoryId = puzzle?.categoryId ?? 'uncategorized';
+      const categoryName = puzzle?.category?.name ?? 'Uncategorized';
+
+      const entry = byCategory.get(categoryId) ?? {
+        categoryName,
+        correct: 0,
+        total: 0,
+      };
+      entry.total += 1;
+      if (attempt.status === AttemptStatus.CORRECT) entry.correct += 1;
+      byCategory.set(categoryId, entry);
+    }
+
+    return [...byCategory.entries()].map(([categoryId, entry]) => ({
+      categoryId,
+      categoryName: entry.categoryName,
+      correct: entry.correct,
+      total: entry.total,
+      accuracy: entry.total > 0 ? Math.round((entry.correct / entry.total) * 100) : 0,
+    }));
+  }
+
+  /**
+   * Updates the user's streak on session completion and returns the
+   * before/after snapshot. Skipped for guest sessions (no userId) and for
+   * sessions with no completed challenges (nothing meaningful to reward).
+   */
+  private async applyStreakUpdate(
+    userId: string | null,
+    userTimezone: string,
+    challengesCompleted: number,
+  ): Promise<{ previousStreak: number | null; currentStreak: number | null }> {
+    if (!userId || challengesCompleted === 0) {
+      return { previousStreak: null, currentStreak: null };
+    }
+
+    const streakBefore = await this.streaksService.getStreak(userId);
+    const previousStreak = streakBefore?.currentStreak ?? 0;
+
+    const streakAfter = await this.streaksService.updateStreak(
+      userId,
+      userTimezone,
+    );
+
+    return { previousStreak, currentStreak: streakAfter.currentStreak };
+  }
+}

--- a/backend/src/rewards/rewards.module.ts
+++ b/backend/src/rewards/rewards.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { RewardService } from './providers/reward.service';
+
+@Module({
+  providers: [RewardService],
+  exports: [RewardService],
+})
+export class RewardsModule {}

--- a/frontend/app/sessions/[id]/complete/page.tsx
+++ b/frontend/app/sessions/[id]/complete/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import React from "react";
+import { useParams, useRouter } from "next/navigation";
+import { SessionCompleteScreen } from "@/components/session/SessionCompleteScreen";
+import { useSessionCompletion } from "@/hooks/useSessionCompletion";
+import { useGuestSession } from "@/hooks/useGuestSession";
+import Button from "@/components/Button";
+
+export default function SessionCompletePage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const { session: guestSession } = useGuestSession();
+
+  const sessionId = typeof params?.id === "string" ? params.id : undefined;
+  const guestId = guestSession?.sessionId ?? null;
+
+  const { session, isLoading, error, refetch } = useSessionCompletion(
+    sessionId,
+    guestId,
+  );
+
+  if (isLoading) {
+    return (
+      <CenteredLayout>
+        <p className="text-[#E6E6E6] text-base animate-fade-in">
+          Calculating your results…
+        </p>
+      </CenteredLayout>
+    );
+  }
+
+  if (error || !session) {
+    return (
+      <CenteredLayout>
+        <div className="flex flex-col items-center gap-4 text-center max-w-sm">
+          <p className="text-white text-lg font-bold">
+            We couldn&apos;t load your results
+          </p>
+          <p className="text-[#9CA3AF] text-sm">
+            {error ?? "This session could not be found."}
+          </p>
+          <Button onClick={refetch} variant="primary">
+            Try Again
+          </Button>
+        </div>
+      </CenteredLayout>
+    );
+  }
+
+  return (
+    <CenteredLayout>
+      <SessionCompleteScreen
+        session={session}
+        onPlayAgain={() => router.push("/puzzle-list")}
+        onViewProfile={() => router.push("/profile")}
+        onReturnHome={() => router.push("/dashboard")}
+      />
+    </CenteredLayout>
+  );
+}
+
+function CenteredLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center px-4">
+      {children}
+    </div>
+  );
+}

--- a/frontend/components/session/SessionCompleteScreen.tsx
+++ b/frontend/components/session/SessionCompleteScreen.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import React from "react";
+import Button from "../Button";
+import {
+  Award,
+  Clock3,
+  Diamond,
+  Flame,
+  Target,
+  Trophy,
+} from "lucide-react";
+import { Nunito } from "next/font/google";
+import type {
+  CategoryPerformanceEntry,
+  GameSessionSummary,
+} from "@/lib/api/gameSessionsApi";
+
+const nunito = Nunito({
+  subsets: ["latin"],
+  weight: ["400", "600", "700", "800", "900"],
+  display: "swap",
+});
+
+interface SessionCompleteScreenProps {
+  session: GameSessionSummary;
+  onPlayAgain: () => void;
+  onViewProfile: () => void;
+  onReturnHome: () => void;
+}
+
+/**
+ * The "🎉 Session Complete!" screen (issue #618).
+ *
+ * Every value shown here comes directly from the persisted GameSession
+ * returned by the backend — nothing is calculated on the frontend, so a
+ * page refresh always shows the same results.
+ */
+export function SessionCompleteScreen({
+  session,
+  onPlayAgain,
+  onViewProfile,
+  onReturnHome,
+}: SessionCompleteScreenProps) {
+  const timeSpentLabel = formatDuration(session.timeSpentSeconds);
+  const streakChange = getStreakChangeLabel(
+    session.previousStreak,
+    session.currentStreak,
+  );
+
+  return (
+    <div
+      className={`${nunito.className} flex flex-col items-center max-w-[640px] w-full justify-center space-y-8 md:space-y-10 px-4 py-10 animate-fade-in`}
+    >
+      <Header />
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 md:gap-4 w-full max-w-[520px]">
+        <StatCard
+          label="SCORE"
+          value={session.score}
+          color="#3B82F6"
+          icon={<Diamond className="h-8 w-8 md:h-10 md:w-10" fill="#3B82F6" />}
+          delay={0}
+        />
+        <StatCard
+          label="XP EARNED"
+          value={session.xpEarned}
+          color="#A855F7"
+          icon={<Award className="h-8 w-8 md:h-10 md:w-10" stroke="#A855F7" />}
+          delay={80}
+        />
+        <StatCard
+          label="ACCURACY"
+          value={session.accuracy !== null ? `${session.accuracy}%` : "—"}
+          color="#14B8A6"
+          icon={<Target className="h-8 w-8 md:h-10 md:w-10" stroke="#14B8A6" />}
+          delay={160}
+        />
+        <StatCard
+          label="CHALLENGES"
+          value={session.challengeCount}
+          color="#F59E0B"
+          icon={<Trophy className="h-8 w-8 md:h-10 md:w-10" stroke="#F59E0B" />}
+          delay={240}
+        />
+        <StatCard
+          label="TIME"
+          value={timeSpentLabel}
+          color="#EC4899"
+          icon={<Clock3 className="h-8 w-8 md:h-10 md:w-10" stroke="#EC4899" />}
+          delay={320}
+        />
+        <StatCard
+          label="STREAK"
+          value={session.currentStreak ?? "—"}
+          color="#EF4444"
+          icon={<Flame className="h-8 w-8 md:h-10 md:w-10" stroke="#EF4444" />}
+          delay={400}
+        />
+      </div>
+
+      {streakChange && (
+        <p className="text-[#E6E6E6] text-sm md:text-base text-center animate-fade-in">
+          {streakChange}
+        </p>
+      )}
+
+      <CategoryPerformanceList categories={session.categoryPerformance} />
+
+      <RewardBanner
+        eligible={session.rewardEligible}
+        reason={session.rewardReason}
+      />
+
+      <div className="w-full max-w-[520px] flex flex-col gap-3 animate-slide-in-from-bottom">
+        <Button onClick={onPlayAgain} className="w-full" variant="primary">
+          Play Again
+        </Button>
+        <div className="flex gap-3">
+          <Button
+            onClick={onViewProfile}
+            className="flex-1"
+            variant="secondary"
+          >
+            View Profile
+          </Button>
+          <Button
+            onClick={onReturnHome}
+            className="flex-1"
+            variant="tertiary"
+          >
+            Return Home
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Header() {
+  return (
+    <div className="text-center flex flex-col space-y-3 md:space-y-4 animate-slide-in-from-top">
+      <div className="text-6xl md:text-8xl animate-bounce-slow">🎉</div>
+      <div className="flex flex-col">
+        <h1 className="text-2xl md:text-[32px] tracking-wider font-black text-white">
+          Session Complete!
+        </h1>
+        <p className="text-[#E6E6E6] text-sm md:text-base">
+          Nice work, here&apos;s how you did.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+interface StatCardProps {
+  label: string;
+  value: string | number;
+  color: string;
+  icon: React.ReactNode;
+  delay?: number;
+}
+
+function StatCard({ label, value, color, icon, delay = 0 }: StatCardProps) {
+  return (
+    <div
+      className="rounded-3xl overflow-hidden animate-slide-in-from-bottom"
+      style={{ backgroundColor: color, animationDelay: `${delay}ms` }}
+    >
+      <div className="py-1 text-center">
+        <span className="text-[10px] md:text-[12px] font-black text-white tracking-widest">
+          {label}
+        </span>
+      </div>
+      <div className="bg-white flex flex-col items-center w-[96%] mx-auto rounded-3xl justify-center gap-1 py-3">
+        <div>{icon}</div>
+        <span style={{ color }} className="text-base md:text-xl font-black">
+          {value}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function CategoryPerformanceList({
+  categories,
+}: {
+  categories: CategoryPerformanceEntry[] | null;
+}) {
+  if (!categories || categories.length === 0) return null;
+
+  return (
+    <div className="w-full max-w-[520px] flex flex-col gap-2 animate-fade-in">
+      <h2 className="text-[#E6E6E6] text-xs md:text-sm font-bold tracking-widest text-center uppercase">
+        Category Performance
+      </h2>
+      <div className="flex flex-col gap-2">
+        {categories.map((category) => (
+          <div
+            key={category.categoryId}
+            className="flex items-center justify-between rounded-xl bg-[#050C16] border border-[#FFFFFF1A] px-4 py-2"
+          >
+            <span className="text-white text-sm font-semibold">
+              {category.categoryName}
+            </span>
+            <span className="text-[#9CA3AF] text-sm">
+              {category.correct}/{category.total} · {category.accuracy}%
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RewardBanner({
+  eligible,
+  reason,
+}: {
+  eligible: boolean | null;
+  reason: string | null;
+}) {
+  if (eligible === null) return null;
+
+  return (
+    <div
+      className={`w-full max-w-[520px] rounded-xl px-4 py-3 text-center text-sm font-semibold animate-fade-in ${
+        eligible
+          ? "bg-[#FACC15]/10 text-[#FACC15] border border-[#FACC15]/30"
+          : "bg-[#FFFFFF0D] text-[#9CA3AF] border border-[#FFFFFF1A]"
+      }`}
+    >
+      {eligible ? "🏆 Reward earned! " : "Not eligible for a reward this time. "}
+      {reason}
+    </div>
+  );
+}
+
+function formatDuration(totalSeconds: number | null): string {
+  if (totalSeconds === null || totalSeconds < 0) return "—";
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes === 0) return `${seconds}s`;
+  return `${minutes}m ${seconds}s`;
+}
+
+function getStreakChangeLabel(
+  previous: number | null,
+  current: number | null,
+): string | null {
+  if (previous === null || current === null) return null;
+  if (current > previous) return `🔥 Streak increased to ${current} days!`;
+  if (current < previous) return `Streak reset to ${current} days.`;
+  return `Streak holding steady at ${current} days.`;
+}

--- a/frontend/hooks/useSessionCompletion.ts
+++ b/frontend/hooks/useSessionCompletion.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  completeGameSession,
+  getGameSession,
+  GameSessionsApiError,
+  GameSessionSummary,
+} from '@/lib/api/gameSessionsApi';
+
+interface UseSessionCompletionResult {
+  session: GameSessionSummary | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+/**
+ * Loads a session's completion summary by ID.
+ *
+ * If the session isn't COMPLETED yet (e.g. the player just finished their
+ * last challenge and was routed here), it first requests completion so the
+ * backend can calculate and persist the final statistics. From then on it
+ * simply fetches by ID, so refreshing the page always shows the same
+ * persisted results instead of recomputing anything client-side.
+ */
+export function useSessionCompletion(
+  sessionId: string | undefined,
+  guestId?: string | null,
+): UseSessionCompletionResult {
+  const [session, setSession] = useState<GameSessionSummary | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const refetch = useCallback(() => setReloadToken((token) => token + 1), []);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setIsLoading(false);
+      setError('No session ID was provided.');
+      return;
+    }
+
+    let cancelled = false;
+
+    async function load() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        let current = await getGameSession(sessionId as string, guestId);
+
+        if (current.status !== 'COMPLETED') {
+          const timezone =
+            typeof Intl !== 'undefined'
+              ? Intl.DateTimeFormat().resolvedOptions().timeZone
+              : undefined;
+          current = await completeGameSession(sessionId as string, {
+            guestId,
+            userTimezone: timezone,
+          });
+        }
+
+        if (!cancelled) setSession(current);
+      } catch (err) {
+        if (cancelled) return;
+        const message =
+          err instanceof GameSessionsApiError
+            ? err.message
+            : 'Something went wrong loading your results.';
+        setError(message);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, guestId, reloadToken]);
+
+  return { session, isLoading, error, refetch };
+}

--- a/frontend/lib/api/gameSessionsApi.ts
+++ b/frontend/lib/api/gameSessionsApi.ts
@@ -1,0 +1,143 @@
+/**
+ * Game Sessions API
+ *
+ * Thin client for the backend's `/game-sessions` REST endpoints:
+ *   GET   /game-sessions/:id           - fetch a session (with computed
+ *                                         completion summary once COMPLETED)
+ *   PATCH /game-sessions/:id/status    - transition a session's status
+ *
+ * All completion statistics (score, xp, accuracy, category performance,
+ * streak, reward eligibility) are calculated server-side. This client only
+ * reads and displays them; it never computes them on the frontend.
+ */
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+export type GameSessionStatus =
+  | 'CREATED'
+  | 'ACTIVE'
+  | 'PAUSED'
+  | 'COMPLETED'
+  | 'EXPIRED'
+  | 'ABANDONED';
+
+export interface CategoryPerformanceEntry {
+  categoryId: string;
+  categoryName: string;
+  correct: number;
+  total: number;
+  accuracy: number;
+}
+
+export interface GameSessionSummary {
+  id: string;
+  userId: string | null;
+  guestId: string | null;
+  status: GameSessionStatus;
+  difficulty: string | null;
+  selectedCategories: string[] | null;
+  challengeCount: number;
+  currentChallenge: number;
+  score: number;
+  xpEarned: number;
+  startedAt: string | null;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  accuracy: number | null;
+  timeSpentSeconds: number | null;
+  categoryPerformance: CategoryPerformanceEntry[] | null;
+  previousStreak: number | null;
+  currentStreak: number | null;
+  rewardEligible: boolean | null;
+  rewardReason: string | null;
+}
+
+export class GameSessionsApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode?: number,
+    public details?: unknown,
+  ) {
+    super(message);
+    this.name = 'GameSessionsApiError';
+  }
+}
+
+function authHeaders(): Record<string, string> {
+  const token =
+    typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new GameSessionsApiError(
+      (errorData as { message?: string }).message ||
+        `Request failed with status ${response.status}`,
+      response.status,
+      errorData,
+    );
+  }
+  return (await response.json()) as T;
+}
+
+/**
+ * Fetches a single game session, including its completion summary if the
+ * session has reached COMPLETED. Safe to call repeatedly (e.g. on page
+ * refresh) since results are persisted server-side.
+ */
+export async function getGameSession(
+  id: string,
+  guestId?: string | null,
+): Promise<GameSessionSummary> {
+  const query = guestId ? `?guestId=${encodeURIComponent(guestId)}` : '';
+  try {
+    const response = await fetch(`${API_BASE_URL}/game-sessions/${id}${query}`, {
+      method: 'GET',
+      headers: authHeaders(),
+    });
+    return await handleResponse<GameSessionSummary>(response);
+  } catch (error) {
+    if (error instanceof GameSessionsApiError) throw error;
+    throw new GameSessionsApiError(
+      'Unable to load session results. Please check your connection.',
+    );
+  }
+}
+
+/**
+ * Marks a session as COMPLETED. The backend calculates all final
+ * statistics server-side from persisted challenge attempts; the optional
+ * score/xpEarned fields here are only used as a fallback when the session
+ * has no tracked attempts.
+ */
+export async function completeGameSession(
+  id: string,
+  options?: { guestId?: string | null; userTimezone?: string },
+): Promise<GameSessionSummary> {
+  const guestId = options?.guestId;
+  const query = guestId ? `?guestId=${encodeURIComponent(guestId)}` : '';
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/game-sessions/${id}/status${query}`,
+      {
+        method: 'PATCH',
+        headers: authHeaders(),
+        body: JSON.stringify({
+          status: 'COMPLETED',
+          userTimezone: options?.userTimezone,
+        }),
+      },
+    );
+    return await handleResponse<GameSessionSummary>(response);
+  } catch (error) {
+    if (error instanceof GameSessionsApiError) throw error;
+    throw new GameSessionsApiError(
+      'Unable to complete the session. Please check your connection.',
+    );
+  }
+}


### PR DESCRIPTION
- Calculate final session stats (score, xp, accuracy, category performance, time spent) server-side from persisted ChallengeAttempt records instead of trusting client-supplied score/xp
- Wire StreaksService and RewardService into session completion
- Persist completion summary on GameSession so results survive a refresh
- Add SessionCompleteScreen UI wired to the real game-sessions API

closes #618 