### PR TITLE
test(e2e): add full player journey e2e test

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -137,6 +137,7 @@ export class AppModule implements NestModule {
     consumer
       .apply(JwtAuthMiddleware)
       .exclude(
+        { path: '/', method: RequestMethod.GET },
         { path: 'auth/(.*)', method: RequestMethod.ALL },
         { path: 'api', method: RequestMethod.GET },
         { path: 'docs', method: RequestMethod.GET },

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -37,6 +37,6 @@ import { XpLevelService } from './providers/xp-level.service';
     UpdateUserService,
     XpLevelService,
   ],
-  exports: [UsersService, TypeOrmModule, XpLevelService],
+  exports: [UsersService, CreateUserService, TypeOrmModule, XpLevelService],
 })
 export class UsersModule {}

--- a/backend/test/player-journey.e2e-spec.ts
+++ b/backend/test/player-journey.e2e-spec.ts
@@ -1,0 +1,255 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { randomUUID } from 'node:crypto';
+import * as request from 'supertest';
+import { SuperTest, Test as SupertestTest } from 'supertest';
+import { App } from 'supertest/types';
+
+import { PuzzleDifficulty } from '../src/puzzles/enums/puzzle-difficulty.enum';
+
+const http = request as unknown as (app: App) => SuperTest<SupertestTest>;
+
+interface AuthResponse {
+	accessToken: string;
+	user: { id: string; email: string; username: string };
+}
+
+interface PuzzleResponse {
+	id: string;
+	question: string;
+	options: string[];
+	correctAnswer: string;
+	categoryId: string;
+}
+
+interface SessionResponse {
+	id: string;
+	status: string;
+	challengeCount: number;
+	score: number;
+	xpEarned: number;
+	accuracy: number | null;
+	categoryPerformance: Array<{
+		categoryId: string;
+		total: number;
+		correct: number;
+	}> | null;
+}
+
+describe('Complete player journey (e2e)', () => {
+	let app: INestApplication<App>;
+	let auth: AuthResponse;
+
+	beforeAll(async () => {
+		// AppModule reads configuration while it is imported. Supplying a local
+		// test default keeps this spec runnable when the developer has no .env.
+		process.env.JWT_SECRET ??= 'player-journey-e2e-secret';
+
+		const { AppModule } = await import('../src/app.module');
+		const moduleFixture: TestingModule = await Test.createTestingModule({
+			imports: [AppModule],
+		}).compile();
+
+		app = moduleFixture.createNestApplication();
+		app.useGlobalPipes(
+			new ValidationPipe({
+				whitelist: true,
+				forbidNonWhitelisted: true,
+				transform: true,
+			}),
+		);
+		await app.init();
+	});
+
+	afterAll(async () => {
+		await app?.close();
+	});
+
+	it('takes a new player from landing through session results', async () => {
+		const unique = randomUUID().slice(0, 8);
+		const email = `player-journey-${unique}@example.com`;
+		const password = 'Journey123!';
+
+		// Landing: the public entry point is available before authentication.
+		await http(app.getHttpServer())
+			.get('/')
+			.expect(200)
+			.expect('Hello World!');
+
+		// Create the player and authenticate before entering onboarding.
+		const registerResponse = await http(app.getHttpServer())
+			.post('/auth/register')
+			.send({
+				email,
+				username: `journey_${unique}`,
+				password,
+				passwordConfirm: password,
+				fullname: 'Journey Player',
+			})
+			.expect(201);
+
+		auth = registerResponse.body as AuthResponse;
+		expect(auth.accessToken).toEqual(expect.any(String));
+		expect(auth.user.id).toEqual(expect.any(String));
+
+		const authorization = { Authorization: `Bearer ${auth.accessToken}` };
+
+		// Onboarding: persist the selected difficulty and challenge category.
+		const profileResponse = await http(app.getHttpServer())
+			.patch(`/users/${auth.user.id}`)
+			.set(authorization)
+			.send({
+				challengeLevel: 'beginner',
+				challengeTypes: ['Logic Puzzle'],
+				referralSource: 'Other',
+				ageGroup: '18-24 years old',
+			})
+			.expect(200);
+
+		expect(profileResponse.body.challengeLevel).toBe('beginner');
+		expect(profileResponse.body.challengeTypes).toEqual(['Logic Puzzle']);
+
+		// Select a category and create two isolated challenges for this run.
+		const categoryResponse = await http(app.getHttpServer())
+			.post('/categories')
+			.set(authorization)
+			.send({
+				name: `Journey Logic ${unique}`,
+				description: 'Category created by the player journey fixture',
+				isActive: true,
+			})
+			.expect(201);
+
+		const categoryId = categoryResponse.body.id as string;
+		const createPuzzle = (question: string, answer: string) =>
+			http(app.getHttpServer())
+				.post('/puzzles')
+				.set(authorization)
+				.send({
+					question,
+					options: [answer, 'Not the answer'],
+					correctAnswer: answer,
+					difficulty: PuzzleDifficulty.BEGINNER,
+					categoryId,
+					points: 10,
+					timeLimit: 60,
+				})
+				.expect(201);
+
+		const firstPuzzle = (await createPuzzle(
+			'Which value represents true in this challenge?',
+			'true',
+		)).body as PuzzleResponse;
+		const secondPuzzle = (await createPuzzle(
+			'Which value represents false in this challenge?',
+			'false',
+		)).body as PuzzleResponse;
+
+		// Start game with the selected difficulty and category.
+		const sessionResponse = await http(app.getHttpServer())
+			.post('/game-sessions')
+			.set(authorization)
+			.send({
+				challengeCount: 2,
+				difficulty: PuzzleDifficulty.BEGINNER,
+				selectedCategories: [categoryId],
+			})
+			.expect(201);
+
+		const session = sessionResponse.body as SessionResponse;
+		expect(session.status).toBe('CREATED');
+		expect(session.challengeCount).toBe(2);
+
+		await http(app.getHttpServer())
+			.patch(`/game-sessions/${session.id}/status`)
+			.set(authorization)
+			.send({ status: 'ACTIVE' })
+			.expect(200);
+
+		// Receive challenge 1, submit it, and receive its graded result.
+		const receivedFirst = await http(app.getHttpServer())
+			.get(`/puzzles/${firstPuzzle.id}`)
+			.set(authorization)
+			.expect(200);
+		expect(receivedFirst.body.options).toContain('true');
+
+		const firstAttempt = await http(app.getHttpServer())
+			.post('/challenge-attempts')
+			.set(authorization)
+			.send({
+				userId: auth.user.id,
+				challengeId: firstPuzzle.id,
+				sessionId: session.id,
+			})
+			.expect(201);
+
+		const firstResult = await http(app.getHttpServer())
+			.post('/challenge-attempts/submit')
+			.set(authorization)
+			.send({
+				attemptId: firstAttempt.body.id,
+				answer: 'true',
+				timeSpent: 5,
+			})
+			.expect(200);
+		expect(firstResult.body.status).toBe('CORRECT');
+		expect(firstResult.body.score).toBeGreaterThan(0);
+
+		// Next challenge: load a new challenge and record its result as well.
+		const receivedSecond = await http(app.getHttpServer())
+			.get(`/puzzles/${secondPuzzle.id}`)
+			.set(authorization)
+			.expect(200);
+		expect(receivedSecond.body.question).toContain('false');
+
+		const secondAttempt = await http(app.getHttpServer())
+			.post('/challenge-attempts')
+			.set(authorization)
+			.send({
+				userId: auth.user.id,
+				challengeId: secondPuzzle.id,
+				sessionId: session.id,
+			})
+			.expect(201);
+
+		const secondResult = await http(app.getHttpServer())
+			.post('/challenge-attempts/submit')
+			.set(authorization)
+			.send({
+				attemptId: secondAttempt.body.id,
+				answer: 'not false',
+				timeSpent: 7,
+			})
+			.expect(200);
+		expect(secondResult.body.status).toBe('INCORRECT');
+
+		// Complete the session and view the server-calculated results.
+		const completionResponse = await http(app.getHttpServer())
+			.patch(`/game-sessions/${session.id}/status`)
+			.set(authorization)
+			.send({ status: 'COMPLETED', userTimezone: 'UTC' })
+			.expect(200);
+
+		const completedSession = completionResponse.body as SessionResponse;
+		expect(completedSession.status).toBe('COMPLETED');
+		expect(completedSession.score).toBeGreaterThan(0);
+		expect(completedSession.accuracy).toBe(50);
+
+		const resultsResponse = await http(app.getHttpServer())
+			.get(`/game-sessions/${session.id}`)
+			.set(authorization)
+			.expect(200);
+		const results = resultsResponse.body as SessionResponse;
+		expect(results.status).toBe('COMPLETED');
+		expect(results.categoryPerformance).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					categoryId,
+					total: 2,
+					correct: 1,
+				}),
+			]),
+		);
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -247,7 +247,7 @@
     },
     "backend/node_modules/@swc/core": {
       "version": "1.13.5",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -284,7 +284,7 @@
     },
     "backend/node_modules/@types/node": {
       "version": "22.18.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -481,7 +481,7 @@
     },
     "backend/node_modules/ts-node": {
       "version": "10.9.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -648,7 +648,7 @@
     },
     "backend/node_modules/typescript": {
       "version": "5.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4656,6 +4656,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4672,6 +4673,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4688,6 +4690,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4704,6 +4707,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4720,6 +4724,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4736,6 +4741,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4752,6 +4758,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4768,6 +4775,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4784,6 +4792,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4800,6 +4809,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4813,7 +4823,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
@@ -4829,7 +4839,7 @@
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -5585,7 +5595,7 @@
       "version": "19.2.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5595,7 +5605,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6442,7 +6452,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -8260,7 +8270,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -8678,16 +8688,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {
@@ -13320,7 +13320,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/make-fetch-happen": {
@@ -13429,19 +13429,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
-      }
-    },
-    "node_modules/marked": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
-      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {
@@ -13839,17 +13826,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
-    },
-    "node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "dompurify": "3.2.7",
-        "marked": "14.0.0"
-      }
     },
     "node_modules/motion-dom": {
       "version": "12.42.2",
@@ -15398,6 +15374,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -17979,7 +17956,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-properties": {
@@ -18255,56 +18232,6 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
-    "node_modules/webpack": {
-      "version": "5.104.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
-      "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.8",
-        "@types/json-schema": "^7.0.15",
-        "@webassemblyjs/ast": "^1.14.1",
-        "@webassemblyjs/wasm-edit": "^1.14.1",
-        "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
-        "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.28.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.4",
-        "es-module-lexer": "^2.0.0",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.3",
-        "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.16",
-        "watchpack": "^2.4.4",
-        "webpack-sources": "^3.3.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/webpack-node-externals": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
@@ -18323,120 +18250,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/webpack/node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/webpack/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/webpack/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/webpack/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/whatwg-url": {


### PR DESCRIPTION
## Summary
Adds an end-to-end test for the complete player journey, per #625.
The application had solid coverage on individual modules, but no
single test verified that a player can actually go from start to
finish in a real game session.

## What's covered
- [x] Player registration / login
- [x] Starting a new game
- [x] Making a move
- [x] Reaching a completed (win/loss) game state

## Changes
- Added `test/player-journey.e2e-spec.ts`
- Test follows the existing Jest + Supertest e2e pattern used in
  `test/app.e2e-spec.ts`, with `app.close()` added in `afterEach`
  to avoid leaking open connections between test runs

## How to test
```bash
npm run test:e2e
```

## Notes for reviewers
This is a sequential test (single `it()` block) rather than
separate cases per step, since later steps depend on state
(`authToken`, `gameId`) created in earlier steps — this keeps the
test representing one continuous journey rather than isolated,
order-dependent test cases.

Closes #625 