### PR TITLE
feat(analytics): register ScheduleModule in AnalyticsModule

### DIFF
--- a/backend/src/analytics/analytics.module.ts
+++ b/backend/src/analytics/analytics.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
 import { AnalyticsEvent } from './entities/analytics-event.entity';
 import { RetentionCohort } from './entities/retention-cohort.entity';
 import { DailyActiveUser } from './entities/daily-active-user.entity';
@@ -21,6 +22,7 @@ import { RetentionCohortRollupJob } from './jobs/retention-cohort-rollup.job';
 
 @Module({
   imports: [
+    ScheduleModule.forRoot(),
     TypeOrmModule.forFeature([
       AnalyticsEvent,
       RetentionCohort,
@@ -55,6 +57,5 @@ import { RetentionCohortRollupJob } from './jobs/retention-cohort-rollup.job';
     ExportCsvProvider,
     TypeOrmModule,
   ],
-
 })
 export class AnalyticsModule {}


### PR DESCRIPTION
## Summary

Closes #545

Registers `ScheduleModule.forRoot()` inside `AnalyticsModule` and adds the corresponding import so the module explicitly declares its dependency on the NestJS task-scheduler. The dependency `@nestjs/schedule` was already present in `backend/package.json` at `^6.0.0` (installed: v6.1.0); this change wires it into the module that actually owns the three cron-job providers.

## Why

Before this change, `AnalyticsModule` registered `DailyActiveUsersRollupJob`, `QuestAnalyticsRollupJob`, and `RetentionCohortRollupJob` as providers, and each of those classes decorates its `handleCron` method with `@Cron()`. However, `AnalyticsModule` never imported `ScheduleModule`, meaning the module did not explicitly declare the scheduling dependency it required. `ScheduleModule.forRoot()` was present in `AppModule` and kept the decorators functional at runtime, but that represented an implicit, fragile coupling — removing or restructuring `AppModule` could silently break all three rollup jobs without any compile-time or module-level signal.

Adding `ScheduleModule.forRoot()` to `AnalyticsModule` makes the dependency explicit at the module boundary, which is consistent with the project's pattern of self-describing feature modules.

## What was built

| File | What it contains |
|---|---|
| `backend/src/analytics/analytics.module.ts` | Added `import { ScheduleModule } from '@nestjs/schedule'` and `ScheduleModule.forRoot()` as the first entry in the `imports` array. Removed the pre-existing spurious blank line inside the `@Module` decorator to satisfy prettier. |

No new source files were added. The three rollup-job classes and their `@Cron()`-decorated `handleCron` methods are unchanged.

## Integration changes outside `analytics/`

> No existing files outside `backend/src/analytics/analytics.module.ts` were modified; the implementation is purely additive within the analytics module.

## Acceptance criteria coverage

- [x] `@nestjs/schedule` added to `backend/package.json` — already present at `^6.0.0` (v6.1.0 installed) before this PR; confirmed via `package.json` line 32 and `node_modules/@nestjs/schedule/package.json`.
- [x] `ScheduleModule` registered without breaking existing module bootstrap — `ScheduleModule.forRoot()` added to `AnalyticsModule` imports; 180/180 tests pass and production build succeeds with zero new errors.

## Deliberately deferred

None. Both acceptance criteria are fully satisfied by this PR.

## Test plan

- [x] `npm --workspace backend run test -- --forceExit` — 180/180 passing (0 new tests; existing job specs cover `@Cron`-decorated handlers)
- [x] `npx tsc -p tsconfig.build.json --noEmit` — 0 type errors
- [x] `npx eslint src/analytics/analytics.module.ts` — 0 errors, 0 warnings
- [x] `npm --workspace backend run build` — succeeds (exit 0)

## Env vars / Notes

No new environment variables are introduced. `ScheduleModule.forRoot()` accepts no configuration here — the default scheduler options (using the system clock, no timezone override) are appropriate for UTC-anchored nightly rollups already hardcoded in the job classes.