### PR TITLE
feat(analytics): strip or hash PII in analytics event metadata

### DIFF
--- a/backend/src/analytics/providers/track-event.provider.spec.ts
+++ b/backend/src/analytics/providers/track-event.provider.spec.ts
@@ -232,4 +232,135 @@ describe('TrackEventProvider', () => {
       );
     });
   });
+
+  describe('PII sanitization', () => {
+    const HASH_PATTERN = /^sha256:[0-9a-f]{16}$/;
+
+    /** Mocks create/save as identity passthroughs so the sanitized payload survives to the response. */
+    function mockRepositoryAsPassthrough() {
+      repository.create.mockImplementation(
+        (data: any) => data as AnalyticsEvent,
+      );
+      repository.save.mockImplementation(async (data: any) => ({
+        id: 'evt-uuid-pii',
+        ...(data as object),
+        timestamp: new Date('2026-08-01T00:00:00.000Z'),
+      }));
+    }
+
+    it('should strip or hash known PII field names from a deliberately dirty payload before insert', async () => {
+      mockRepositoryAsPassthrough();
+
+      const dto: TrackEventDto = {
+        eventType: 'profile_updated',
+        userId: 'user-pii-1',
+        payload: {
+          entityId: 'profile-1',
+          email: 'jane.doe@example.com',
+          walletAddress: '0xAbC1234567890000000000000000000000dEaD',
+          password: 'super-secret-password',
+          accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+          difficulty: 'hard', // non-PII — must survive untouched
+          nested: {
+            phoneNumber: '+1-555-123-4567',
+            note: 'call me anytime',
+          },
+        },
+      };
+
+      const result = await provider.track(dto);
+      const persistedPayload = result.data.payload as Record<string, any>;
+
+      // Non-PII fields, including nested ones, pass through unchanged.
+      expect(persistedPayload.entityId).toBe('profile-1');
+      expect(persistedPayload.difficulty).toBe('hard');
+      expect(persistedPayload.nested.note).toBe('call me anytime');
+
+      // Credentials/secrets are dropped entirely — no analytics value even hashed.
+      expect(persistedPayload.password).toBeUndefined();
+      expect(persistedPayload.accessToken).toBeUndefined();
+
+      // Correlatable PII is hashed, never stored raw.
+      expect(persistedPayload.email).not.toBe('jane.doe@example.com');
+      expect(persistedPayload.email).toMatch(HASH_PATTERN);
+      expect(persistedPayload.walletAddress).not.toBe(
+        '0xAbC1234567890000000000000000000000dEaD',
+      );
+      expect(persistedPayload.walletAddress).toMatch(HASH_PATTERN);
+      expect(persistedPayload.nested.phoneNumber).not.toBe('+1-555-123-4567');
+      expect(persistedPayload.nested.phoneNumber).toMatch(HASH_PATTERN);
+
+      // Final sweep: none of the raw sensitive values appear anywhere in
+      // what actually gets written, however it's nested.
+      const serialized = JSON.stringify(persistedPayload);
+      expect(serialized).not.toContain('jane.doe@example.com');
+      expect(serialized).not.toContain(
+        '0xAbC1234567890000000000000000000000dEaD',
+      );
+      expect(serialized).not.toContain('super-secret-password');
+      expect(serialized).not.toContain('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9');
+      expect(serialized).not.toContain('+1-555-123-4567');
+    });
+
+    it('should hash PII field names case-insensitively', async () => {
+      mockRepositoryAsPassthrough();
+
+      const dto: TrackEventDto = {
+        eventType: 'signup_completed',
+        userId: 'user-pii-2',
+        payload: { Email: 'Weird.Casing@Example.com', WALLETADDRESS: '0xdead' },
+      };
+
+      const result = await provider.track(dto);
+      const persistedPayload = result.data.payload as Record<string, any>;
+
+      expect(persistedPayload.Email).toMatch(HASH_PATTERN);
+      expect(persistedPayload.WALLETADDRESS).toMatch(HASH_PATTERN);
+    });
+
+    it('should hash the same raw value to the same hash deterministically, enabling correlation without exposing PII', async () => {
+      mockRepositoryAsPassthrough();
+
+      const makeDto = (): TrackEventDto => ({
+        eventType: 'wallet_connected',
+        userId: 'user-1',
+        payload: {
+          walletAddress: '0xSAMEADDRESS0000000000000000000000000000',
+        },
+      });
+
+      const first = await provider.track(makeDto());
+      const second = await provider.track(makeDto());
+
+      const firstPayload = first.data.payload as Record<string, any>;
+      const secondPayload = second.data.payload as Record<string, any>;
+
+      expect(firstPayload.walletAddress).toBe(secondPayload.walletAddress);
+      expect(firstPayload.walletAddress).toMatch(HASH_PATTERN);
+    });
+
+    it('should leave a payload with no PII fields completely unaffected', async () => {
+      mockRepositoryAsPassthrough();
+
+      const dto: TrackEventDto = {
+        eventType: 'puzzle_attempted',
+        userId: 'user-clean',
+        payload: { entityId: 'puzzle-1', difficulty: 'easy', timeSpent: 12 },
+      };
+
+      const result = await provider.track(dto);
+
+      expect(result.data.payload).toEqual(dto.payload);
+    });
+
+    it('should return undefined payload unchanged when no payload is provided', async () => {
+      mockRepositoryAsPassthrough();
+
+      const dto: TrackEventDto = { eventType: 'session_started' };
+
+      const result = await provider.track(dto);
+
+      expect(result.data.payload).toBeUndefined();
+    });
+  });
 });

--- a/backend/src/analytics/providers/track-event.provider.ts
+++ b/backend/src/analytics/providers/track-event.provider.ts
@@ -1,8 +1,45 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { createHash } from 'crypto';
 import { AnalyticsEvent } from '../entities/analytics-event.entity';
 import { TrackEventDto } from '../dtos/track-event.dto';
+
+/**
+ * Metadata field names (case-insensitive) that are hashed rather than
+ * dropped: the raw value has no place in a table queried broadly across
+ * many roles, but a stable one-way hash still lets analytics group/dedupe
+ * on "same value" without exposing the original PII.
+ */
+const HASHED_FIELD_NAMES = new Set([
+  'email',
+  'emailaddress',
+  'wallet',
+  'walletaddress',
+  'stellarwallet',
+  'phone',
+  'phonenumber',
+  'ipaddress',
+  'ip',
+]);
+
+/**
+ * Metadata field names (case-insensitive) that are dropped entirely —
+ * credentials/secrets have no analytics value even hashed, and keeping a
+ * hash of a password/token is still a liability if the hashing scheme is
+ * ever reused elsewhere.
+ */
+const STRIPPED_FIELD_NAMES = new Set([
+  'password',
+  'token',
+  'accesstoken',
+  'refreshtoken',
+  'secret',
+  'apikey',
+  'ssn',
+  'creditcard',
+  'authorization',
+]);
 
 @Injectable()
 export class TrackEventProvider {
@@ -16,7 +53,7 @@ export class TrackEventProvider {
       eventType: dto.eventType,
       userId: dto.userId ?? '',
       entityId: dto.payload?.entityId ?? '',
-      payload: dto.payload,
+      payload: this.sanitizeMetadata(dto.payload),
     });
 
     const saved = await this.analyticsEventRepository.save(event);
@@ -26,5 +63,57 @@ export class TrackEventProvider {
       message: 'Event tracked successfully',
       data: saved,
     };
+  }
+
+  /**
+   * Strips or hashes known-PII field names from a free-form metadata
+   * payload before it's persisted to `analytics_events`. Recurses into
+   * nested objects/arrays since `payload` is arbitrary caller-supplied JSON,
+   * not a fixed schema.
+   */
+  private sanitizeMetadata(
+    payload: Record<string, any> | undefined,
+  ): Record<string, any> | undefined {
+    if (payload === undefined || payload === null) {
+      return payload;
+    }
+    return this.sanitizeValue(payload) as Record<string, any>;
+  }
+
+  private sanitizeValue(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.sanitizeValue(item));
+    }
+
+    if (value !== null && typeof value === 'object') {
+      const sanitized: Record<string, any> = {};
+      for (const [key, fieldValue] of Object.entries(
+        value as Record<string, any>,
+      )) {
+        const normalizedKey = key.toLowerCase();
+
+        if (STRIPPED_FIELD_NAMES.has(normalizedKey)) {
+          continue;
+        }
+
+        if (
+          HASHED_FIELD_NAMES.has(normalizedKey) &&
+          typeof fieldValue === 'string'
+        ) {
+          sanitized[key] = this.hash(fieldValue);
+          continue;
+        }
+
+        sanitized[key] = this.sanitizeValue(fieldValue);
+      }
+      return sanitized;
+    }
+
+    return value;
+  }
+
+  /** One-way, deterministic hash so repeated values still correlate in analytics. */
+  private hash(value: string): string {
+    return `sha256:${createHash('sha256').update(value).digest('hex').slice(0, 16)}`;
   }
 }


### PR DESCRIPTION
closes #553
Sanitizes emails, wallet addresses, and other known PII fields in analytics event metadata before persistence, per the acceptance criteria.

Analytics tables get queried broadly across many roles, so they shouldn't become an unintentional store of sensitive user data. TrackEventProvider now sanitizes the free-form metadata payload before persisting to AnalyticsEvent:

- Known PII field names (email, walletAddress, phone, ip, ...) are hashed (SHA-256, truncated, prefixed) rather than dropped, so analytics can still group/dedupe by same value without ever storing the raw value.
- Credential-shaped field names (password, token, secret, apiKey, ...) are stripped entirely — no analytics value even hashed.
- Matching is case-insensitive and recurses into nested objects/arrays, since payload is arbitrary caller-supplied JSON, not a fixed schema.
- Non-PII fields, including nested ones, pass through unchanged.

Covered by unit tests using a deliberately dirty payload (mixed PII, secrets, and legitimate fields, some nested), plus tests for case-insensitive matching, deterministic hashing, and no-op on clean payloads.